### PR TITLE
Allow setting of a :base_path configuration to remove hostnames from URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 2.2.2
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -109,6 +109,39 @@ Will generate the following HTML:
 </picture>
 ```
 
+### Hostname Removal
+
+You can also configure imgix-rails to disregard given hostnames and only use the path component from given URLs. This is useful if you have [a Web Folder or an Amazon S3 imgix Source configured](https://www.imgix.com/docs/tutorials/creating-sources) but store the fully-qualified URLs for those resources in your database.
+
+For example, let's say you are using S3 for storage. An `#avatar_url` value might look like the following in your application:
+
+```ruby
+@user.avatar_url #=> "https://s3.amazonaws.com/my-bucket/users/1.png"
+```
+
+You would then configure imgix in your Rails application to disregard the `'s3.amazonaws.com'` hostname:
+
+```ruby
+Rails.application.configure do
+  config.imgix = {
+    source: "my-imgix-source.imgix.net",
+    hostname_to_replace: "s3.amazonaws.com"
+  }
+end
+```
+
+Now when you call `ix_image_tag` or another helper, you get an imgix URL:
+
+```erb
+<%= ix_image_tag(@user.avatar_url) %>
+```
+
+Renders:
+
+```html
+<img src="https://my-imgix-source.imgix.net/my-bucket/users/1.png" />
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
**Use case:**

I'm running an application on Heroku and am handling file uploads. We upload the files directly to S3 to get around the low max request times on Heroku. Thus, we store the fully-qualified URLs for images in our database.

I would like a way to have `imgix-rails` drop the protocol and hostname from input paths.