### PR TITLE
Fix responsive URLs with hostname replacement

### DIFF
--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -86,6 +86,7 @@ module Imgix
       end
 
       def srcset_for(source, options={})
+        source = replace_hostname(source)
         configured_resolutions.map do |resolution|
           srcset_options = options.slice(*available_parameters)
           srcset_options[:dpr] = resolution unless resolution == 1


### PR DESCRIPTION
Hostname replacement was not being applied to alternate resolutions when using the responsive image helper.