### PR TITLE
Correcting configuration option name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following configuration flags will be respected:
 - `:secure:` toggles the use of HTTPS. Deafults to `true`
 - `:source` a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
 - `:secure_url_token` a optional secure URL token found in your dashboard (https://webapp.imgix.com) used for signing requests
-- `:hostnames_to_remove` an Array of hostnames to replace with the value(s) specified by `:source`. This is useful if you store full-qualified S3 URLs in your database, but want to serve images through imgix.
+- `:hostnames_to_replace` an Array of hostnames to replace with the value(s) specified by `:source`. This is useful if you store full-qualified S3 URLs in your database, but want to serve images through imgix.
 
 ### ix_image_tag
 


### PR DESCRIPTION
While integrating this library today, I was initially confused when the configuration option `hostnames_to_remove` wasn't acting as expected. After reading the spec files I noticed the correct configuration variable is `hostnames_to_replace`, so I updated the README to reflect this. 

Thanks for the integration! It's pretty sweet. 