### PR TITLE
Namespace client variable to avoid conflicts

### DIFF
--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -62,7 +62,7 @@ module Imgix
       end
 
       def client
-        return @client if @client
+        return @imgix_client if @imgix_client
         imgix = ::Imgix::Rails.config.imgix
 
         opts = {
@@ -84,7 +84,7 @@ module Imgix
           opts[:secure] = imgix[:secure]
         end
 
-        @client = ::Imgix::Client.new(opts)
+        @imgix_client = ::Imgix::Client.new(opts)
       end
 
       def available_parameters


### PR DESCRIPTION
In my project I have a @client variable in one of my controller that conflict with the instance variable declared in imgix-rails helpers.
So I prefixed the @client variable with imgix_