### PR TITLE
Extract UrlHelper out of ViewHelper

### DIFF
--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -1,0 +1,71 @@
+module Imgix
+  module Rails
+    class ConfigurationError < StandardError; end
+
+    module UrlHelper
+      def ix_image_url(source, options={})
+        validate_configuration!
+
+        source = replace_hostname(source)
+
+        client.path(source).to_url(options).html_safe
+      end
+
+      private
+
+      def validate_configuration!
+        imgix = ::Imgix::Rails.config.imgix
+        unless imgix.try(:[], :source)
+          raise ConfigurationError.new("imgix source is not configured. Please set config.imgix[:source].")
+        end
+
+        unless imgix[:source].is_a?(Array) || imgix[:source].is_a?(String)
+          raise ConfigurationError.new("imgix source must be a String or an Array.")
+        end
+      end
+
+      def replace_hostname(source)
+        new_source = source.dup
+
+        # Replace any hostnames configured to trim things down just to their paths.
+        # We use split to remove the protocol in the process.
+        hostnames_to_remove.each do |hostname|
+          splits = source.split(hostname)
+          new_source = splits.last if splits.size > 1
+        end
+
+        new_source
+      end
+
+      def hostnames_to_remove
+        Array(::Imgix::Rails.config.imgix[:hostname_to_replace] || ::Imgix::Rails.config.imgix[:hostnames_to_replace])
+      end
+
+      def client
+        return @imgix_client if @imgix_client
+        imgix = ::Imgix::Rails.config.imgix
+
+        opts = {
+          host: imgix[:source],
+          library_param: "rails",
+          library_version: Imgix::Rails::VERSION,
+          secure: true
+        }
+
+        if imgix[:secure_url_token].present?
+          opts[:token] = imgix[:secure_url_token]
+        end
+
+        if imgix.has_key?(:include_library_param)
+          opts[:include_library_param] = imgix[:include_library_param]
+        end
+
+        if imgix.has_key?(:secure)
+          opts[:secure] = imgix[:secure]
+        end
+
+        @imgix_client = ::Imgix::Client.new(opts)
+      end
+    end
+  end
+end

--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -1,17 +1,10 @@
 require "imgix"
+require 'imgix/rails/url_helper'
 
 module Imgix
   module Rails
-    class ConfigurationError < StandardError; end
-
-    module ViewHelper
-      def ix_image_url(source, options={})
-        validate_configuration!
-
-        source = replace_hostname(source)
-
-        client.path(source).to_url(options).html_safe
-      end
+   module ViewHelper
+      include UrlHelper
 
       def ix_image_tag(source, options={})
         source = replace_hostname(source)
@@ -37,56 +30,6 @@ module Imgix
 
     private
 
-      def validate_configuration!
-        imgix = ::Imgix::Rails.config.imgix
-        unless imgix.try(:[], :source)
-          raise ConfigurationError.new("imgix source is not configured. Please set config.imgix[:source].")
-        end
-
-        unless imgix[:source].is_a?(Array) || imgix[:source].is_a?(String)
-          raise ConfigurationError.new("imgix source must be a String or an Array.")
-        end
-      end
-
-      def replace_hostname(source)
-        new_source = source.dup
-
-        # Replace any hostnames configured to trim things down just to their paths.
-        # We use split to remove the protocol in the process.
-        hostnames_to_remove.each do |hostname|
-          splits = source.split(hostname)
-          new_source = splits.last if splits.size > 1
-        end
-
-        new_source
-      end
-
-      def client
-        return @imgix_client if @imgix_client
-        imgix = ::Imgix::Rails.config.imgix
-
-        opts = {
-          host: imgix[:source],
-          library_param: "rails",
-          library_version: Imgix::Rails::VERSION,
-          secure: true
-        }
-
-        if imgix[:secure_url_token].present?
-          opts[:token] = imgix[:secure_url_token]
-        end
-
-        if imgix.has_key?(:include_library_param)
-          opts[:include_library_param] = imgix[:include_library_param]
-        end
-
-        if imgix.has_key?(:secure)
-          opts[:secure] = imgix[:secure]
-        end
-
-        @imgix_client = ::Imgix::Client.new(opts)
-      end
-
       def available_parameters
         @available_parameters ||= parameters.keys
       end
@@ -107,10 +50,6 @@ module Imgix
 
       def configured_resolutions
         ::Imgix::Rails.config.imgix[:responsive_resolutions] || [1, 2]
-      end
-
-      def hostnames_to_remove
-        Array(::Imgix::Rails.config.imgix[:hostname_to_replace] || ::Imgix::Rails.config.imgix[:hostnames_to_replace])
       end
     end
   end

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -1,0 +1,123 @@
+require 'imgix/rails_spec'
+require 'imgix/rails/url_helper'
+
+describe Imgix::Rails::UrlHelper do
+  let(:truncated_version) { Imgix::Rails::VERSION.split(".").first(2).join(".") }
+  let(:url_helper) do
+    Class.new do
+      include ActionView::Helpers::AssetTagHelper
+      include ActionView::Helpers::TextHelper
+      include Imgix::Rails::UrlHelper
+      include ActionView::Context
+    end.new
+  end
+
+  before do
+    Imgix::Rails.configure { |config| config.imgix = {} }
+  end
+
+  describe 'configuration' do
+    let(:app) { Class.new(::Rails::Application) }
+    let(:source) { "assets.imgix.net" }
+
+    before do
+      Imgix::Rails.configure { |config| config.imgix = {} }
+    end
+
+    it 'expects config.imgix.source to be defined' do
+      expect{
+        url_helper.ix_image_url("assets.png")
+      }.to raise_error(Imgix::Rails::ConfigurationError, "imgix source is not configured. Please set config.imgix[:source].")
+    end
+
+    it 'expects config.imgix.source to be a String or an Array' do
+      Imgix::Rails.configure { |config| config.imgix = { source: 1 } }
+
+      expect{
+        url_helper.ix_image_url("assets.png")
+      }.to raise_error(Imgix::Rails::ConfigurationError, "imgix source must be a String or an Array.")
+    end
+
+    it 'optionally expects config.imgix.secure_url_token to be defined' do
+      Imgix::Rails.configure do |config|
+        config.imgix = {
+          source: 'assets.imgix.net',
+          secure_url_token: 'FACEBEEF'
+        }
+      end
+
+      expect{
+        url_helper.ix_image_url("assets.png")
+      }.not_to raise_error
+    end
+
+    describe ':secure' do
+      it 'defaults to https' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source
+          }
+        end
+
+        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+      end
+
+      it 'respects the :secure flag' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source,
+            secure: false
+          }
+        end
+
+        expect(url_helper.ix_image_url("image.jpg")).to eq  "http://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+      end
+    end
+
+    describe 'hostname removal' do
+      let(:hostname) { 's3.amazonaws.com' }
+      let(:another_hostname) { 's3-us-west-2.amazonaws.com' }
+      let(:yet_another_hostname) { 's3-sa-east-1.amazonaws.com' }
+      let(:app) { Class.new(::Rails::Application) }
+      let(:source) { "assets.imgix.net" }
+
+      before do
+        Imgix::Rails.configure { |config| config.imgix = { source: source } }
+      end
+
+      it 'does not remove a hostname for a fully-qualified URL' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source,
+            hostname_to_replace: hostname
+          }
+        end
+
+        expect(url_helper.ix_image_url("https://adifferenthostname.com/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/https%3A%2F%2Fadifferenthostname.com%2Fimage.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
+      end
+
+      it 'removes a single hostname' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source,
+            hostname_to_replace: hostname
+          }
+        end
+
+        expect(url_helper.ix_image_url("https://#{hostname}/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
+      end
+
+      it 'removes multiple configured protocol/hostname combos' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source,
+            hostnames_to_replace: [another_hostname, yet_another_hostname]
+          }
+        end
+
+        expect(url_helper.ix_image_url("https://#{another_hostname}/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
+        expect(url_helper.ix_image_url("https://#{yet_another_hostname}/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Target use case: We use imgix-rails in a Serializer.  This will allow a user to use the `ViewHelper` in a Rails View in their app, and also have the `UrlHelper` for their serializers.  Having a seperate `UrlHelper` prevents importing the tag-helpers into one's json serializers, while importing only the `ix_image_url` helper.