### PR TITLE
Updated to use imgix-rb 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ end
 
 The following configuration flags will be respected:
 
-- `:secure:` toggles the use of HTTPS. Defaults to `true`
+- `:use_https` toggles the use of HTTPS. Defaults to `true`
 - `:source` a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
 - `:secure_url_token` a optional secure URL token found in your dashboard (https://webapp.imgix.com) used for signing requests
 - `:hostnames_to_replace` an Array of hostnames to replace with the value(s) specified by `:source`. This is useful if you store full-qualified S3 URLs in your database, but want to serve images through imgix.

--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -6,9 +6,9 @@ require 'imgix/rails/version'
 Gem::Specification.new do |spec|
   spec.name          = "imgix-rails"
   spec.version       = Imgix::Rails::VERSION
-  spec.authors       = ["Kelly Sutton"]
-  spec.email         = ["kelly@imgix.com"]
-  spec.licenses      = ['MIT']
+  spec.authors       = ["Kelly Sutton", "Paul Straw"]
+  spec.email         = ["kelly@imgix.com", "ixemail"]
+  spec.licenses      = ["MIT"]
 
   spec.summary       = %q{Makes integrating imgix into your Rails app easier. It builds on imgix-rb to offer a few Rails-specific interfaces.}
   spec.description   = %q{Makes integrating imgix into your Rails app easier. It builds on imgix-rb to offer a few Rails-specific interfaces. Please see https://github.com/imgix/imgix-rails for more details.}
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "imgix", '~> 0.3', '>= 0.3.5'
+  spec.add_runtime_dependency "imgix", "~> 1.0", ">= 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -49,19 +49,16 @@ module Imgix
           host: imgix[:source],
           library_param: "rails",
           library_version: Imgix::Rails::VERSION,
-          secure: true
+          use_https: true,
+          secure_url_token: imgix[:secure_url_token]
         }
-
-        if imgix[:secure_url_token].present?
-          opts[:token] = imgix[:secure_url_token]
-        end
 
         if imgix.has_key?(:include_library_param)
           opts[:include_library_param] = imgix[:include_library_param]
         end
 
-        if imgix.has_key?(:secure)
-          opts[:secure] = imgix[:secure]
+        if imgix.has_key?(:use_https)
+          opts[:use_https] = imgix[:use_https]
         end
 
         @imgix_client = ::Imgix::Client.new(opts)

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -51,7 +51,7 @@ describe Imgix::Rails::UrlHelper do
       }.not_to raise_error
     end
 
-    describe ':secure' do
+    describe ':use_https' do
       it 'defaults to https' do
         Imgix::Rails.configure do |config|
           config.imgix = {
@@ -62,11 +62,11 @@ describe Imgix::Rails::UrlHelper do
         expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
       end
 
-      it 'respects the :secure flag' do
+      it 'respects the :use_https flag' do
         Imgix::Rails.configure do |config|
           config.imgix = {
             source: source,
-            secure: false
+            use_https: false
           }
         end
 

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -63,7 +63,7 @@ describe Imgix::Rails do
       }.not_to raise_error
     end
 
-    describe ':secure' do
+    describe ':use_https' do
       it 'defaults to https' do
         Imgix::Rails.configure do |config|
           config.imgix = {
@@ -74,11 +74,11 @@ describe Imgix::Rails do
         expect(helper.ix_image_tag("image.jpg")).to eq  "<img src=\"https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}\" alt=\"Image.jpg?ixlib=rails #{truncated_version}\" />"
       end
 
-      it 'respects the :secure flag' do
+      it 'respects the :use_https flag' do
         Imgix::Rails.configure do |config|
           config.imgix = {
             source: source,
-            secure: false
+            use_https: false
           }
         end
 
@@ -169,13 +169,13 @@ describe Imgix::Rails do
           }
         end
 
-        expect(helper.ix_image_url("/users/1.png")).to eq "https://assets.imgix.net/users/1.png?&s=3d97566c016f6e1e6679bf981941e6f4"
+        expect(helper.ix_image_url("/users/1.png")).to eq "https://assets.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c"
       end
     end
 
     describe '#ix_image_tag' do
       it 'prints an image_tag' do
-        expect(helper.ix_image_tag("image.jpg")).to eq  "<img src=\"https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}\" alt=\"Image.jpg?ixlib=rails #{truncated_version}\" />"
+        expect(helper.ix_image_tag("image.jpg")).to eq "<img src=\"https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}\" alt=\"Image.jpg?ixlib=rails #{truncated_version}\" />"
       end
 
       it 'passes through non-imgix tags' do


### PR DESCRIPTION
Probably not worth bumping to 1.0.0 to match imgix-rb, since the only breaking change is from `:secure` to `:use_https` in the config. Maybe 0.4.0 instead? At least this gets the two Ruby libs aligned.