### PR TITLE
Prefix client method helper by imgix_

### DIFF
--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -8,7 +8,7 @@ module Imgix
 
         source = replace_hostname(source)
 
-        client.path(source).to_url(options).html_safe
+        imgix_client.path(source).to_url(options).html_safe
       end
 
       private
@@ -41,7 +41,7 @@ module Imgix
         Array(::Imgix::Rails.config.imgix[:hostname_to_replace] || ::Imgix::Rails.config.imgix[:hostnames_to_replace])
       end
 
-      def client
+      def imgix_client
         return @imgix_client if @imgix_client
         imgix = ::Imgix::Rails.config.imgix
 


### PR DESCRIPTION
Because I have another method called `client` in my app, there is a conflict.
So I prefixed your method by `imgix_`.

I know it is a private method but ... you know private methods in Rails helpers ...
http://stackoverflow.com/questions/12835367/why-can-private-helper-methods-still-be-accessed-in-views

