### PR TITLE
Keep `widths` option out of image tag query params

### DIFF
--- a/lib/imgix/rails/image_tag.rb
+++ b/lib/imgix/rails/image_tag.rb
@@ -8,6 +8,6 @@ class Imgix::Rails::ImageTag < Imgix::Rails::Tag
     @source = replace_hostname(@source)
     normal_opts = @options.slice!(*self.class.available_parameters)
 
-    image_tag(ix_image_url(@source, @options), normal_opts)
+    image_tag(ix_image_url(@source, @options.except(:widths)), normal_opts)
   end
 end

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -35,7 +35,7 @@ protected
     widths = opts[:widths] || target_widths
 
     widths.map do |width|
-      srcset_options = opts.slice(*self.class.available_parameters)
+      srcset_options = opts.slice(*self.class.available_parameters).except(:widths)
       srcset_options[:w] = width
 
       if opts[:w].present? && opts[:h].present?

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -212,6 +212,16 @@ describe Imgix::Rails do
         expect(tag.attribute('widths')).to be_nil
       end
 
+      it 'does not include `widths` as a query parameter in the generated `srcset`' do
+        tag = Nokogiri::HTML.fragment(helper.ix_image_tag('image.jpg', widths: [10, 20, 30], w: 400, h: 300)).children[0]
+        expect(tag.attribute('srcset').value).not_to include('widths')
+      end
+
+      it 'does not include `widths` as a query parameter in the generated `src`' do
+        tag = Nokogiri::HTML.fragment(helper.ix_image_tag('image.jpg', widths: [10, 20, 30], w: 400, h: 300)).children[0]
+        expect(tag.attribute('src').value).not_to include('widths')
+      end
+
       it 'applies the client-hints parameter' do
         tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", ch: "Width,DPR")).children[0]
         expect(tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&ch=Width%2CDPR")


### PR DESCRIPTION
This PR is intended to ensure that the `widths` option given to the `image_tag()` function doesn't accidentally make its way as a query parameter into either the `srcset` or `src` attributes of the generated image tag.

This PR fixes #43.

@Tailzip @cherifzouein @lucianopanaro @emaraschio I'm not a native Rubyist, so I'd love to get a quick review from one of you before this goes out.