### PR TITLE
fix(readme): missing comma ix_image_tag example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Then rendering the portrait in your application is very easy:
 If you already know all the exact widths you need images for, you can specify that by passing the `widths` option as an array. In this case, imgix-rails will only generate `srcset` pairs for the specified `widths`.
 
 ```erb
-<%= ix_image_tag('/unsplash/hotairballoon.jpg', { widths: [320, 640, 960, 1280] w: 300, h: 500, fit: 'crop', crop: 'right', alt: 'A hot air balloon on a sunny day' }) %>
+<%= ix_image_tag('/unsplash/hotairballoon.jpg', { widths: [320, 640, 960, 1280], w: 300, h: 500, fit: 'crop', crop: 'right', alt: 'A hot air balloon on a sunny day' }) %>
 ```
 
 


### PR DESCRIPTION
Each parameter should be seperated with a comma.