### PR TITLE
Use hosts option when source is an Array

### DIFF
--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -50,12 +50,17 @@ module Imgix
         imgix = ::Imgix::Rails.config.imgix
 
         opts = {
-          host: imgix[:source],
           library_param: "rails",
           library_version: Imgix::Rails::VERSION,
           use_https: true,
           secure_url_token: imgix[:secure_url_token]
         }
+
+        if imgix[:source].is_a?(String)
+          opts[:host] = imgix[:source]
+        else
+          opts[:hosts] = imgix[:source]
+        end
 
         if imgix.has_key?(:include_library_param)
           opts[:include_library_param] = imgix[:include_library_param]

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -50,6 +50,28 @@ describe Imgix::Rails::UrlHelper do
       }.not_to raise_error
     end
 
+    describe 'support host/hosts' do
+      it 'sets host if source is a String' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source
+          }
+        end
+
+        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+      end
+
+      it 'sets hosts if source is an Array' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: [source]
+          }
+        end
+
+        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+      end
+    end
+
     describe ':use_https' do
       it 'defaults to https' do
         Imgix::Rails.configure do |config|


### PR DESCRIPTION
Since imgix-rb supports both host and hosts option (https://github.com/imgix/imgix-rb/blob/master/lib/imgix/client.rb#L12), not sure if you'd like this PR.

It basically sets hosts option for Imgix::Client instead of host if source is an Array.