### PR TITLE
Update screen sizes used for srcset generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following configuration flags will be respected:
 
 - `:use_https` toggles the use of HTTPS. Defaults to `true`
 - `:source` a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
+- `:srcset_width_tolerance` an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `.08` i.e. `8%`).
 - `:secure_url_token` an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
 - `:shard_strategy` Specify [domain sharding strategy](https://github.com/imgix/imgix-rb#domain-sharded-urls) with multiple sources. Acceptable values are `:cycle` and `:crc`. `:crc` is used by default.
 

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -17,8 +17,8 @@ protected
   def srcset(url_params: @url_params, widths: @widths)
     widths = widths || target_widths
 
-    widths.map do |width|
-      srcset_url_params = url_params.clone
+    srcset_url_params = url_params.clone
+    srcsetvalue = widths.map do |width|
       srcset_url_params[:w] = width
 
       if url_params[:w].present? && url_params[:h].present?
@@ -27,131 +27,55 @@ protected
 
       "#{ix_image_url(@source, @path, srcset_url_params)} #{width}w"
     end.join(', ')
+
+    srcsetvalue += ", #{ix_image_url(@source, @path, srcset_url_params.except(:w, :h))}"
+  end
+
+  @@standard_widths = nil
+
+  def compute_standard_widths
+    tolerance = ::Imgix::Rails.config.imgix[:srcset_width_tolerance] || SRCSET_TOLERANCE
+    prev = MINIMUM_SCREEN_WIDTH
+    widths = []
+    while prev <= MAXIMUM_SCREEN_WIDTH do
+      widths.append(2 * (prev/2).round)   # Ensure widths are even
+      prev = prev * (1 + tolerance*2.0)
+    end
+
+    widths
+  end
+
+  def standard_widths
+    return @@standard_widths if @@standard_widths
+
+    @@standard_widths = compute_standard_widths
+    @@standard_widths.freeze
+
+    @@standard_widths
   end
 
 private
 
-  MAXIMUM_SCREEN_WIDTH = 2560 * 2 # Physical resolution of 27" iMac (2016)
-  SCREEN_STEP = 100
-
-  # Taken from http://mydevice.io/devices/
-
-  # Phones
-  IPHONE = { css_width: 320, dpr: 1 }
-  IPHONE_4 = { css_width: 320, dpr: 2 }
-  IPHONE_6 = { css_width: 375, dpr: 2 }
-  LG_G3 = { css_width: 360, dpr: 4 }
-
-  # Phablets
-  IPHONE_6_PLUS = { css_width: 414, dpr: 3 }
-  IPHONE_6_PLUS_LANDSCAPE = { css_width: 736, dpr: 3 }
-  MOTO_NEXUS_6 = { css_width: 412, dpr: 3.5 }
-  MOTO_NEXUS_6_LANDSCAPE = { css_width: 690, dpr: 3.5 }
-  LUMIA_1520 = { css_width: 432, dpr: 2.5 }
-  LUMIA_1520_LANDSCAPE = { css_width: 768, dpr: 2.5 }
-  GALAXY_NOTE_3 = { css_width: 360, dpr: 3 }
-  GALAXY_NOTE_3_LANDSCAPE = { css_width: 640, dpr: 3 }
-  GALAXY_NOTE_4 = { css_width: 360, dpr: 4 }
-  GALAXY_NOTE_4_LANDSCAPE = { css_width: 640, dpr: 4 }
-
-  # Tablets
-  IPAD = { css_width: 768, dpr: 1 };
-  IPAD_LANDSCAPE = { css_width: 1024, dpr: 1 };
-  IPAD_3 = { css_width: 768, dpr: 2 };
-  IPAD_3_LANDSCAPE = { css_width: 1024, dpr: 2 };
-  IPAD_PRO = { css_width: 1024, dpr: 2 };
-  IPAD_PRO_LANDSCAPE = { css_width: 1366, dpr: 2 };
-
-  BOOTSTRAP_SM = { css_width: 576, dpr: 1 }
-  BOOTSTRAP_MD = { css_width: 720, dpr: 1 }
-  BOOTSTRAP_LG = { css_width: 940, dpr: 1 }
-  BOOTSTRAP_XL = { css_width: 1140, dpr: 1 }
-
-  def devices
-    phones + phablets + tablets + bootstrap_breaks
-  end
-
-  def bootstrap_breaks
-    breaks = [
-      BOOTSTRAP_SM,
-      BOOTSTRAP_MD,
-      BOOTSTRAP_LG,
-      BOOTSTRAP_XL
-    ]
-
-    breaks + breaks.map { |b| b[:dpr] = 2; b }
-  end
-
-  def phones
-    [
-      IPHONE,
-      IPHONE_4,
-      IPHONE_6,
-      LG_G3
-    ]
-  end
-
-  def phablets
-    [
-      IPHONE_6_PLUS,
-      IPHONE_6_PLUS_LANDSCAPE,
-      MOTO_NEXUS_6,
-      MOTO_NEXUS_6_LANDSCAPE,
-      LUMIA_1520,
-      LUMIA_1520_LANDSCAPE,
-      GALAXY_NOTE_3,
-      GALAXY_NOTE_3_LANDSCAPE,
-      GALAXY_NOTE_4,
-      GALAXY_NOTE_4_LANDSCAPE
-    ]
-  end
-
-  def tablets
-    [
-      IPAD,
-      IPAD_LANDSCAPE,
-      IPAD_3,
-      IPAD_3_LANDSCAPE,
-      IPAD_PRO,
-      IPAD_PRO_LANDSCAPE
-    ]
-  end
+  MINIMUM_SCREEN_WIDTH = 100
+  MAXIMUM_SCREEN_WIDTH = 8192   # Maximum width supported by imgix
+  SRCSET_TOLERANCE = 0.08
 
   # Return the widths to generate given the input `sizes`
   # attribute.
   #
   # @return {Array} An array of {Fixnum} instances representing the unique `srcset` URLs to generate.
   def target_widths
-    min_screen_width_required = @tag_options[:min_width] || SCREEN_STEP
-    max_screen_width_required = @tag_options[:max_width] || MAXIMUM_SCREEN_WIDTH
-
-    widths = (device_widths + screen_widths).select do |w|
-      w <= max_screen_width_required && w >= min_screen_width_required
-    end.compact.uniq.sort
-
-    # Add exact widths for 1x, 2x, and 3x devices
-    if @url_params[:w]
-      widths.push(@url_params[:w], @url_params[:w] * 2, @url_params[:w] * 3)
+    min_width = @tag_options[:min_width]
+    max_width = @tag_options[:max_width]
+    if min_width || max_width
+      min_width = min_width || MINIMUM_SCREEN_WIDTH
+      max_width = max_width || MAXIMUM_SCREEN_WIDTH
+      widths = standard_widths.select { |w| min_width <= w && w <= max_width }
+    else
+      widths = standard_widths
     end
 
     widths
   end
 
-  def device_widths
-    devices.map do |device|
-      (device[:css_width] * device[:dpr]).round
-    end
-  end
-
-  # Generates an array of physical screen widths to represent
-  # the different potential viewport sizes.
-  #
-  # We step by `SCREEN_STEP` to give some sanity to the amount
-  # of widths we output.
-  #
-  # The upper bound is the widest known screen on the planet.
-  # @return {Array} An array of {Fixnum} instances
-  def screen_widths
-    (0..MAXIMUM_SCREEN_WIDTH).step(SCREEN_STEP).to_a + [MAXIMUM_SCREEN_WIDTH]
-  end
 end


### PR DESCRIPTION
This PR updates the screen sizes used for `srcset` generation in `img` and `picture` tag. The library doesn't maintain a list of standard screen resolutions, and instead calculates screen sizes using the following criteria:

- Smallest size is 100px
- Maximum size is 2560*2=5120px (27" iMac resolution)
- Screen size incremented by 16% consecutively from the smallest size to the maximum size. This gives a tolerance of 8% for the desired image size.

The user can still override the widths by using `widths` parameter.