### PR TITLE
Add support for multiple imgix sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ We recommend using something like [Paperclip](https://github.com/thoughtbot/pape
   * [ix_picture_tag](#ix_picture_tag)
   * [ix_image_url](#ix_image_url)
     * [Usage in Sprockets](#usage-in-sprockets)
-  * [Hostname Removal](#hostname-removal)
 * [Using With Image Uploading Libraries](#using-with-image-uploading-libraries)
   * [Paperclip and CarrierWave](#paperclip-and-carrierwave)
   * [Refile](#refile)
@@ -50,7 +49,7 @@ Before you get started, you will need to define your imgix configuration in your
 ```ruby
 Rails.application.configure do
   config.imgix = {
-    source: "Name of your source, e.g. assets.imgix.net"
+    source: "assets.imgix.net"
   }
 end
 ```
@@ -59,9 +58,29 @@ The following configuration flags will be respected:
 
 - `:use_https` toggles the use of HTTPS. Defaults to `true`
 - `:source` a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
-- `:secure_url_token` a optional secure URL token found in your dashboard (https://webapp.imgix.com) used for signing requests
-- `:hostnames_to_replace` an Array of hostnames to replace with the value(s) specified by `:source`. This is useful if you store full-qualified S3 URLs in your database, but want to serve images through imgix.
-- `shard_strategy`: Specify [domain sharding strategy](https://github.com/imgix/imgix-rb#domain-sharded-urls) with multiple sources. Acceptable values are `:cycle` and `:crc`. `:crc` is used by default.
+- `:secure_url_token` an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
+- `:shard_strategy` Specify [domain sharding strategy](https://github.com/imgix/imgix-rb#domain-sharded-urls) with multiple sources. Acceptable values are `:cycle` and `:crc`. `:crc` is used by default.
+
+#### Multi-source configuration
+
+In addition to the standard configuration flags, the following options can be used for multi-source support.
+
+- `:sources` a Hash of imgix source-secure_url_token key-value pairs. If the value for a source is `nil`, URLs generated for the corresponding source won't be secured. `:sources` and `:source` *cannot* be used together.
+- `:default_source` optionally specify a default source for generating URLs.
+
+Example:
+
+```ruby
+Rails.application.configure do
+  config.imgix = {
+    sources: {
+      "assets.imgix.net"  => "foobarbaz",
+      "assets2.imgix.net" => nil,   # Will generate unsigned URLs
+    },
+    default_source: "assets.imgix.net"
+  }
+end
+```
 
 <a name="ix_image_tag"></a>
 ### ix_image_tag
@@ -69,6 +88,13 @@ The following configuration flags will be respected:
 The `ix_image_tag` helper method makes it easy to pass parameters to imgix to handle resizing, cropping, etc. It also simplifies adding responsive imagery to your Rails app by automatically generating a `srcset` based on the parameters you pass. We talk a bit about using the `srcset` attribute in an application in the following blog post: [“Responsive Images with `srcset` and imgix.”](https://blog.imgix.com/2015/08/18/responsive-images-with-srcset-imgix.html).
 
 `ix_image_tag` generates `<img>` tags with a filled-out `srcset` attribute that leans on imgix to do the hard work. If you already know the minimum or maximum number of physical pixels that this image will need to be displayed at, you can pass the `min_width` and/or `max_width` options. This will result in a smaller, more tailored `srcset`.
+
+`ix_image_tag` takes the following arguments:
+
+* `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
+* `path`: The path or URL of the image to display.
+* `tag_options`: Any options to apply to the parent `picture` element. This is useful for adding class names, etc.
+* `url_params`: Default imgix options. These will be used to generate a fallback `img` tag for older browsers, and used in each `source` unless overridden by `breakpoints`.
 
 ```erb
 <%= ix_image_tag('/unsplash/hotairballoon.jpg', url_params: { w: 300, h: 500, fit: 'crop', crop: 'right'}, tag_options: { alt: 'A hot air balloon on a sunny day' }) %>
@@ -89,6 +115,14 @@ Will render out HTML like the following:
   src="https://assets.imgix.net/unsplash/hotairballoon.jpg?w=300&amp;h=500&amp;fit=crop&amp;crop=right"
 >
 ```
+
+Similarly
+
+```erb
+<%= ix_image_tag('assets2.imgix.net', '/unsplash/hotairballoon.jpg') %>
+```
+
+Will generate URLs using `assets2.imgix.net` source.
 
 We recommend leveraging this to generate powerful helpers within your application like the following:
 
@@ -116,14 +150,14 @@ If you already know all the exact widths you need images for, you can specify th
 
 The `ix_picture_tag` helper method makes it easy to generate `picture` elements in your Rails app. `picture` elements are useful when an images needs to be art directed differently at different screen sizes.
 
-`ix_picture_tag` takes four arguments:
+`ix_picture_tag` takes the following arguments:
 
-* `source`: The path or URL of the image to display.
+* `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
+* `path`: The path or URL of the image to display.
 * `tag_options`: Any options to apply to the parent `picture` element. This is useful for adding class names, etc.
 * `url_params`: Default imgix options. These will be used to generate a fallback `img` tag for older browsers, and used in each `source` unless overridden by `breakpoints`.
 * `breakpoints`: A hash describing the variants. Each key must be a media query (e.g. `(max-width: 880px)`), and each value must be a hash of param overrides for that media query. A `source` element will be generated for each breakpoint specified.
-* (deprecated) `picture_tag_options`: Use `tag_options` instead.
-* (deprecated) `imgix_default_options`: Use `url_params` instead.
+
 ```erb
 <%= ix_picture_tag('bertandernie.jpg',
   tag_options: {
@@ -163,20 +197,42 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 ) %>
 ```
 
+To generate a `picture` element on a different source:
+
+```erb
+<%= ix_picture_tag('assets2.imgix.net', 'bertandernie.jpg',
+      tag_options: {},
+      url_params: {},
+      breakpoints: {
+        '(max-width: 640px)' => {
+          url_params: { h: 100 },
+          tag_options: { sizes: 'calc(100vw - 20px)' }
+        },
+      }
+   ) %>
+```
 
 <a name="ix_image_url"></a>
 ### ix_image_url
 
 The `ix_image_url` helper makes it easy to generate a URL to an image in your Rails app.
 
+`ix_image_url` takes four arguments:
+
+* `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
+* `path`: The path or URL of the image to display.
+* `options`: Any options to apply to the parent `picture` element. This is useful for adding class names, etc.
+
 ```erb
 <%= ix_image_url('/users/1/avatar.png', { w: 400, h: 300 }) %>
+<%= ix_image_url('assets2.imgix.net', '/users/1/avatar.png', { w: 400, h: 300 }) %>
 ```
 
-Will generate the following URL:
+Will generate the following URLs:
 
 ```html
 https://assets.imgix.net/users/1/avatar.png?w=400&h=300
+https://assets2.imgix.net/users/1/avatar.png?w=400&h=300
 ```
 
 Since `ix_image_url` lives inside `UrlHelper`, it can also be used in places other than your views quite easily. This is useful for things such as including imgix URLs in JSON output from a serializer class.
@@ -198,40 +254,6 @@ puts ix_image_url('/users/1/avatar.png', { w: 400, h: 300 })
   background-image: url(<%= ix_image_url('a-background.png', { w: 400, h: 300 }) %>);
 }
 ```
-
-### Hostname Removal
-
-You can also configure imgix-rails to disregard given hostnames and only use the path component from given URLs. This is useful if you have [a Web Folder or an Amazon S3 imgix Source configured](https://www.imgix.com/docs/tutorials/creating-sources) but store the fully-qualified URLs for those resources in your database.
-
-For example, let's say you are using S3 for storage. An `#avatar_url` value might look like the following in your application:
-
-```ruby
-@user.avatar_url #=> "https://s3.amazonaws.com/my-bucket/users/1.png"
-```
-
-You would then configure imgix in your Rails application to disregard the `'s3.amazonaws.com'` hostname:
-
-```ruby
-Rails.application.configure do
-  config.imgix = {
-    source: "my-imgix-source.imgix.net",
-    hostname_to_replace: "s3.amazonaws.com"
-  }
-end
-```
-
-Now when you call `ix_image_tag` or another helper, you get an imgix URL:
-
-```erb
-<%= ix_image_tag(@user.avatar_url) %>
-```
-
-Renders:
-
-```html
-<img src="https://my-imgix-source.imgix.net/my-bucket/users/1.png" />
-```
-
 
 <a name="using-with-image-uploading-libraries"></a>
 ## Using With Image Uploading Libraries

--- a/lib/imgix/rails/image_tag.rb
+++ b/lib/imgix/rails/image_tag.rb
@@ -6,8 +6,6 @@ class Imgix::Rails::ImageTag < Imgix::Rails::Tag
     @tag_options[:srcset] = srcset
     @tag_options[:sizes] ||= '100vw'
 
-    @source = replace_hostname(@source)
-
-    image_tag(ix_image_url(@source, @url_params), @tag_options)
+    image_tag(ix_image_url(@source, @path, @url_params), @tag_options)
   end
 end

--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -4,7 +4,8 @@ require "imgix/rails/image_tag"
 class Imgix::Rails::PictureTag < Imgix::Rails::Tag
   include ActionView::Context
 
-  def initialize(source, tag_options: {}, url_params: {}, breakpoints: {}, widths: [])
+  def initialize(path, source: nil, tag_options: {}, url_params: {}, breakpoints: {}, widths: [])
+    @path = path
     @source = source
     @tag_options = tag_options
     @url_params = url_params
@@ -16,7 +17,7 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
     content_tag(:picture, @tag_options) do
       @breakpoints.each do |media, opts|
         source_tag_opts = opts[:tag_options] || {}
-        source_url_params = opts[:url_params] || {}
+        source_tag_url_params = opts[:url_params] || {}
         widths = opts[:widths]
         unsupported_opts = opts.except(:tag_options, :url_params, :widths)
         if unsupported_opts.length > 0
@@ -24,11 +25,11 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
         end
 
         source_tag_opts[:media] ||= media
-        source_tag_opts[:srcset] ||= srcset(url_params: @url_params.clone.merge(source_url_params), widths: widths)
+        source_tag_opts[:srcset] ||= srcset(url_params: @url_params.clone.merge(source_tag_url_params), widths: widths)
         concat(content_tag(:source, nil, source_tag_opts))
       end
 
-      concat Imgix::Rails::ImageTag.new(@source, url_params: @url_params).render
+      concat Imgix::Rails::ImageTag.new(@path, source: @source, url_params: @url_params).render
     end
   end
 end

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -4,7 +4,8 @@ class Imgix::Rails::Tag
   include Imgix::Rails::UrlHelper
   include ActionView::Helpers
 
-  def initialize(source, tag_options: {}, url_params: {}, widths: [])
+  def initialize(path, source: nil, tag_options: {}, url_params: {}, widths: [])
+    @path = path
     @source = source
     @tag_options = tag_options
     @url_params = url_params
@@ -14,7 +15,6 @@ class Imgix::Rails::Tag
 protected
 
   def srcset(url_params: @url_params, widths: @widths)
-    @source = replace_hostname(@source)
     widths = widths || target_widths
 
     widths.map do |width|
@@ -25,7 +25,7 @@ protected
         srcset_url_params[:h] = (width * (url_params[:h].to_f / url_params[:w])).round
       end
 
-      "#{ix_image_url(@source, srcset_url_params)} #{width}w"
+      "#{ix_image_url(@source, @path, srcset_url_params)} #{width}w"
     end.join(', ')
   end
 

--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -3,24 +3,56 @@ module Imgix
     class ConfigurationError < StandardError; end
 
     module UrlHelper
-      def ix_image_url(source, options={})
+      def ix_image_url(*args)
         validate_configuration!
 
-        source = replace_hostname(source)
+        case args.size
+        when 1
+          path = args[0]
+          source = nil
+          options = {}
+        when 2
+          if args[0].is_a?(String) && args[1].is_a?(Hash)
+            source = nil
+            path = args[0]
+            options = args[1]
+          elsif args[0].is_a?(String) && args[1].is_a?(String)
+            source = args[0]
+            path = args[1]
+            options = {}
+          else
+            raise RuntimeError.new("path and source must be of type String; options must be of type Hash")
+          end
+        when 3
+          source = args[0]
+          path = args[1]
+          options = args[2]
+        else
+          raise RuntimeError.new('path missing')
+        end
 
-        imgix_client.path(source).to_url(options).html_safe
+        imgix_client(source).path(path).to_url(options).html_safe
       end
 
       private
 
       def validate_configuration!
         imgix = ::Imgix::Rails.config.imgix
-        unless imgix.try(:[], :source)
-          raise ConfigurationError.new("imgix source is not configured. Please set config.imgix[:source].")
+
+        if imgix.slice(:source, :sources).size != 1
+          raise ConfigurationError.new("Exactly one of :source, :sources is required")
         end
 
-        unless imgix[:source].is_a?(Array) || imgix[:source].is_a?(String)
-          raise ConfigurationError.new("imgix source must be a String or an Array.")
+        if imgix[:source]
+          unless imgix[:source].is_a?(Array) || imgix[:source].is_a?(String)
+            raise ConfigurationError.new("imgix source must be a String or an Array.")
+          end
+        end
+
+        if imgix[:sources]
+          unless imgix[:sources].is_a?(Hash)
+            raise ConfigurationError.new(":sources must be a Hash")
+          end
         end
 
         unless !imgix.key?(:shard_strategy) || STRATEGIES.include?(imgix[:shard_strategy])
@@ -28,33 +60,22 @@ module Imgix
         end
       end
 
-      def replace_hostname(source)
-        new_source = source.dup
-
-        # Replace any hostnames configured to trim things down just to their paths.
-        # We use split to remove the protocol in the process.
-        hostnames_to_remove.each do |hostname|
-          splits = source.split(hostname)
-          new_source = splits.last if splits.size > 1
+      def imgix_client(source)
+        begin
+          return imgix_clients.fetch(source)
+        rescue KeyError
+          raise RuntimeError.new("Unknown source '#{source}'")
         end
-
-        new_source
       end
 
-      def hostnames_to_remove
-        Array(::Imgix::Rails.config.imgix[:hostname_to_replace] || ::Imgix::Rails.config.imgix[:hostnames_to_replace])
-      end
-
-      def imgix_client
-        return @imgix_client if @imgix_client
+      def imgix_clients
+        return @imgix_clients if @imgix_clients
         imgix = ::Imgix::Rails.config.imgix
 
         opts = {
-          host: imgix[:source],
           library_param: "rails",
           library_version: Imgix::Rails::VERSION,
           use_https: true,
-          secure_url_token: imgix[:secure_url_token]
         }
 
         if imgix.has_key?(:include_library_param)
@@ -69,7 +90,21 @@ module Imgix
           opts[:shard_strategy] = imgix[:shard_strategy]
         end
 
-        @imgix_client = ::Imgix::Client.new(opts)
+        sources = imgix[:sources] || { imgix[:source] => imgix[:secure_url_token] }
+        @imgix_clients = {}
+
+        sources.map do |source, token|
+          opts[:host] = source
+          opts[:secure_url_token] = token
+          @imgix_clients[source] = ::Imgix::Client.new(opts)
+        end
+
+        default_source = imgix[:default_source] || imgix[:source]
+        if default_source
+          @imgix_clients[nil] = @imgix_clients.fetch(default_source)
+        end
+
+        @imgix_clients
       end
     end
   end

--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -8,12 +8,12 @@ module Imgix
     module ViewHelper
       include UrlHelper
 
-      def ix_image_tag(source, tag_options: {}, url_params: {}, widths: [])
-        Imgix::Rails::ImageTag.new(source, tag_options: tag_options, url_params: url_params, widths: widths).render
+      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, widths: [])
+        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, widths: widths).render
       end
 
-      def ix_picture_tag(source, tag_options: {}, url_params: {}, breakpoints:)
-        Imgix::Rails::PictureTag.new(source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints).render
+      def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints:)
+        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints).render
       end
     end
   end

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -26,7 +26,7 @@ describe Imgix::Rails::UrlHelper do
     it 'expects config.imgix.source to be defined' do
       expect{
         url_helper.ix_image_url("assets.png")
-      }.to raise_error(Imgix::Rails::ConfigurationError, "imgix source is not configured. Please set config.imgix[:source].")
+      }.to raise_error(Imgix::Rails::ConfigurationError)
     end
 
     it 'expects config.imgix.source to be a String or an Array' do
@@ -70,52 +70,6 @@ describe Imgix::Rails::UrlHelper do
         end
 
         expect(url_helper.ix_image_url("image.jpg")).to eq  "http://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
-      end
-    end
-
-    describe 'hostname removal' do
-      let(:hostname) { 's3.amazonaws.com' }
-      let(:another_hostname) { 's3-us-west-2.amazonaws.com' }
-      let(:yet_another_hostname) { 's3-sa-east-1.amazonaws.com' }
-      let(:app) { Class.new(::Rails::Application) }
-      let(:source) { "assets.imgix.net" }
-
-      before do
-        Imgix::Rails.configure { |config| config.imgix = { source: source } }
-      end
-
-      it 'does not remove a hostname for a fully-qualified URL' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source,
-            hostname_to_replace: hostname
-          }
-        end
-
-        expect(url_helper.ix_image_url("https://adifferenthostname.com/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/https%3A%2F%2Fadifferenthostname.com%2Fimage.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
-      end
-
-      it 'removes a single hostname' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source,
-            hostname_to_replace: hostname
-          }
-        end
-
-        expect(url_helper.ix_image_url("https://#{hostname}/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
-      end
-
-      it 'removes multiple configured protocol/hostname combos' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source,
-            hostnames_to_replace: [another_hostname, yet_another_hostname]
-          }
-        end
-
-        expect(url_helper.ix_image_url("https://#{another_hostname}/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
-        expect(url_helper.ix_image_url("https://#{yet_another_hostname}/image.jpg", w: 400, h: 300)).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300"
       end
     end
 

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -39,7 +39,7 @@ describe Imgix::Rails do
     it 'expects config.imgix.source to be defined' do
       expect{
         helper.ix_image_tag("assets.png")
-      }.to raise_error(Imgix::Rails::ConfigurationError, "imgix source is not configured. Please set config.imgix[:source].")
+      }.to raise_error(Imgix::Rails::ConfigurationError)
     end
 
     it 'expects config.imgix.source to be a String or an Array' do
@@ -87,58 +87,6 @@ describe Imgix::Rails do
         expect(tag.attribute('src').value).to eq("http://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}")
       end
     end
-
-    describe 'hostname removal' do
-      let(:hostname) { 's3.amazonaws.com' }
-      let(:another_hostname) { 's3-us-west-2.amazonaws.com' }
-      let(:yet_another_hostname) { 's3-sa-east-1.amazonaws.com' }
-      let(:app) { Class.new(::Rails::Application) }
-      let(:source) { "assets.imgix.net" }
-
-      before do
-        Imgix::Rails.configure { |config| config.imgix = { source: source } }
-      end
-
-      it 'does not remove a hostname for a fully-qualified URL' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source,
-            hostname_to_replace: hostname
-          }
-        end
-
-        tag = Nokogiri::HTML.fragment(helper.ix_image_tag("https://adifferenthostname.com/image.jpg", url_params: {w: 400, h: 300})).children[0]
-
-        expect(tag.attribute('src').value).to eq("https://assets.imgix.net/https%3A%2F%2Fadifferenthostname.com%2Fimage.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300")
-      end
-
-      it 'removes a single hostname' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source,
-            hostname_to_replace: hostname
-          }
-        end
-
-        tag = Nokogiri::HTML.fragment(helper.ix_image_tag("https://#{hostname}/image.jpg", url_params: {w: 400, h: 300})).children[0]
-        expect(tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300")
-      end
-
-      it 'removes multiple configured protocol/hostname combos' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source,
-            hostnames_to_replace: [another_hostname, yet_another_hostname]
-          }
-        end
-
-        tag = Nokogiri::HTML.fragment(helper.ix_image_tag("https://#{another_hostname}/image.jpg", url_params: {w: 400, h: 300})).children[0]
-        another_tag = Nokogiri::HTML.fragment(helper.ix_image_tag("https://#{yet_another_hostname}/image.jpg", url_params: {w: 400, h: 300})).children[0]
-
-        expect(tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300")
-        expect(another_tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}&w=400&h=300")
-      end
-    end
   end
 
   describe Imgix::Rails::ViewHelper do
@@ -153,6 +101,13 @@ describe Imgix::Rails do
       it 'prints an image URL' do
         expect(helper.ix_image_url("image.jpg")).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
       end
+
+      it 'raises error when path not supplied' do
+        expect{
+          helper.ix_image_url()
+        }.to raise_error
+      end
+
 
       it 'signs image URLs with ixlib=rails' do
         image_url = URI.parse(helper.ix_image_url("image.jpg", { h: 300,  w: 400 }))
@@ -286,18 +241,6 @@ describe Imgix::Rails do
             expect(tag.attribute('srcset').value.split(',').size).to eq(1)
           end
         end
-
-        it 'replaces the hostname' do
-          Imgix::Rails.configure do |config|
-            config.imgix = {
-              source: source,
-              hostnames_to_replace: [another_hostname]
-            }
-          end
-
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("https://#{another_hostname}/image.jpg")).children[0]
-          expect(tag.attribute('srcset').value).not_to include(another_hostname)
-        end
       end
     end
 
@@ -411,7 +354,318 @@ describe Imgix::Rails do
           )
         }.to raise_error(RuntimeError, /key\(s\) not supported/)
       end
+    end
+  end
 
+  describe 'multi-source' do
+    describe 'with default_source specified' do
+      let(:app) { Class.new(::Rails::Application) }
+      let(:sources) { { "assets.imgix.net" => nil, "assets2.imgix.net" => nil } }
+      let(:default_source) { "assets.imgix.net" }
+
+      before do
+        Imgix::Rails.configure { |config| config.imgix = { sources: sources, default_source: default_source } }
+      end
+
+      describe '#ix_image_url' do
+        describe 'prints an image URL' do
+            it 'with no source supplied' do
+              expect(helper.ix_image_url("image.jpg")).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+            end
+
+            it 'with explicit source supplied' do
+              expect(helper.ix_image_url("assets2.imgix.net", "image.jpg")).to eq "https://assets2.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+            end
+        end
+
+        describe 'injects any imgix parameters given' do
+          it 'with no source supplied' do
+            image_url = URI.parse(helper.ix_image_url("image.jpg", { h: 300,  w: 400 }))
+            url_query = CGI::parse(image_url.query)
+
+            expect(url_query['w']).to eq ['400']
+            expect(url_query['h']).to eq ['300']
+          end
+
+          it 'with explicit source supplied' do
+            image_url = URI.parse(helper.ix_image_url("assets2.imgix.net", "image.jpg", { h: 300,  w: 400 }))
+            url_query = CGI::parse(image_url.query)
+
+            expect(url_query['w']).to eq ['400']
+            expect(url_query['h']).to eq ['300']
+          end
+        end
+
+        describe 'signs an image path if a :secure_url_token is given' do
+          before do
+            Imgix::Rails.configure do |config|
+              config.imgix = {
+                sources: {
+                  "assets.imgix.net" => "FOO123bar",
+                  "assets2.imgix.net" => "bazbarfoo",
+                },
+                default_source: "assets.imgix.net",
+                include_library_param: false
+              }
+            end
+          end
+
+          it 'with no source supplied' do
+            expect(helper.ix_image_url("/users/1.png")).to eq "https://assets.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c"
+          end
+
+          it 'with default source explicitly supplied' do
+            expect(helper.ix_image_url("assets.imgix.net", "/users/1.png")).to eq "https://assets.imgix.net/users/1.png?s=6797c24146142d5b40bde3141fd3600c"
+          end
+
+          it 'with different source explicity supplied' do
+            expect(helper.ix_image_url("assets2.imgix.net", "/users/1.png")).to eq "https://assets2.imgix.net/users/1.png?s=07b9d5cf18f35c04f1e1872d9ccfa6ea"
+          end
+        end
+      end
+
+      describe '#ix_image_tag' do
+        describe 'prints an image_tag' do
+          it 'with no source supplied' do
+            tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg")).children[0]
+            expect(tag.name).to eq('img')
+            expect(tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}")
+          end
+
+          it 'with explicit source supplied' do
+            tag = Nokogiri::HTML.fragment(helper.ix_image_tag("assets2.imgix.net", "image.jpg")).children[0]
+            expect(tag.name).to eq('img')
+            expect(tag.attribute('src').value).to eq("https://assets2.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}")
+          end
+        end
+
+        describe 'passes through tag_options, url_params' do
+          it 'with no source supplied' do
+            tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", tag_options: {alt: "No Church in the Wild"}, url_params: {w: 400, h: 300, foo: "bar"})).children[0]
+            expect(tag.attribute('src').value).to include('foo=bar')
+          end
+
+          it 'with explicit source supplied' do
+            tag = Nokogiri::HTML.fragment(helper.ix_image_tag("assets2.imgix.net", "image.jpg", tag_options: {alt: "No Church in the Wild"}, url_params: {w: 400, h: 300, foo: "bar"})).children[0]
+            expect(tag.attribute('src').value).to include('w=400')
+            expect(tag.attribute('src').value).to include('h=300')
+            expect(tag.attribute('src').value).to include('foo=bar')
+            expect(tag.attribute('alt').value).to eq("No Church in the Wild")
+          end
+        end
+      end
+
+      describe '#ix_picture_tag' do
+        let(:tag_options) { { class: 'a-picture-tag' } }
+        let(:url_params) { {
+              w: 300,
+              h: 300,
+              fit: 'crop',
+            } }
+        let(:breakpoints) { {
+              '(max-width: 640px)' => {
+                tag_options: {
+                  sizes: 'calc(100vw - 20px)'
+                },
+                url_params: {
+                  h: 100,
+                }
+              },
+              '(max-width: 880px)' => {
+                url_params: {
+                  crop: 'right'
+                },
+                tag_options: {
+                  sizes: 'calc(100vw - 20px - 50%)'
+                }
+              },
+              '(min-width: 881px)' => {
+                url_params: {
+                  crop: 'left',
+                },
+                tag_options: {
+                  sizes: '430px'
+                }
+              }
+            } }
+
+        describe 'generates a `picture`' do
+          it 'with no source supplied' do
+            picture_tag = helper.ix_picture_tag(
+              'bertandernie.jpg',
+              tag_options: tag_options,
+              url_params: url_params,
+              breakpoints: breakpoints,
+            )
+            tag = Nokogiri::HTML.fragment(picture_tag).children[0]
+            expect(tag.name).to eq('picture')
+            expect(tag.css('img')[0].attribute('src').value).to start_with("https://assets.imgix.net")
+          end
+
+          it 'with explicit source supplied' do
+            picture_tag = helper.ix_picture_tag(
+              'assets2.imgix.net',
+              'bertandernie.jpg',
+              tag_options: tag_options,
+              url_params: url_params,
+              breakpoints: breakpoints,
+            )
+            tag = Nokogiri::HTML.fragment(picture_tag).children[0]
+            expect(tag.name).to eq('picture')
+            expect(tag.css('img')[0].attribute('src').value).to start_with("https://assets2.imgix.net")
+          end
+        end
+
+        describe 'passes through options to the `picture`' do
+          it 'with no source supplied' do
+            picture_tag = helper.ix_picture_tag(
+              'bertandernie.jpg',
+              tag_options: tag_options,
+              url_params: url_params,
+              breakpoints: breakpoints,
+            )
+            tag = Nokogiri::HTML.fragment(picture_tag).children[0]
+            expect(tag.attribute('class').value).to eq('a-picture-tag')
+          end
+
+          it 'with explicit source supplied' do
+            picture_tag = helper.ix_picture_tag(
+              'assets2.imgix.net',
+              'bertandernie.jpg',
+              tag_options: tag_options,
+              url_params: url_params,
+              breakpoints: breakpoints,
+            )
+            tag = Nokogiri::HTML.fragment(picture_tag).children[0]
+            url = tag.css('img')[0].attribute('src').value
+
+            # tag_options
+            expect(tag.attribute('class').value).to eq('a-picture-tag')
+
+            # url_params
+            expect(url).to include("w=300")
+            expect(url).to include("h=300")
+            expect(url).to include("fit=crop")
+
+            # breakpoints
+            expected_media = [
+              '(max-width: 640px)',
+              '(max-width: 880px)',
+              '(min-width: 881px)'
+            ]
+            tag.css('source').each_with_index do |source, i|
+              expect(source.attribute('media').value).to eq(expected_media[i])
+            end
+          end
+        end
+      end
+
+      it 'raises error for unknown source' do
+        expect{
+          helper.ix_image_url("foo.bar", "image.jpg")
+        }.to raise_error(RuntimeError)
+      end
+    end
+
+    describe 'no default_source specified' do
+      let(:app) { Class.new(::Rails::Application) }
+      let(:sources) { { "assets.imgix.net" => nil, "assets2.imgix.net" => nil } }
+
+      before do
+        Imgix::Rails.configure { |config| config.imgix = { sources: sources } }
+      end
+
+      describe '#ix_image_url' do
+        it 'raises error when no source is supplied' do
+          expect{
+            helper.ix_image_url("image.jpg")
+          }.to raise_error(RuntimeError)
+        end
+
+        it "doesn't raise error when source is supplied" do
+          expect{
+            helper.ix_image_url("assets2.imgix.net", "image.jpg")
+          }.not_to raise_error
+        end
+      end
+
+      describe '#ix_image_tag' do
+        it 'raises error when no source is supplied' do
+          expect{
+            helper.ix_image_tag("image.jpg")
+          }.to raise_error(RuntimeError)
+        end
+
+        it "doesn't raise error when source is supplied" do
+          expect{
+            helper.ix_image_tag("assets2.imgix.net", "image.jpg")
+          }.not_to raise_error
+        end
+      end
+
+      describe '#ix_picture_tag' do
+        let(:tag_options) { { class: 'a-picture-tag' } }
+        let(:url_params) { {
+              w: 300,
+              h: 300,
+              fit: 'crop',
+            } }
+        let(:breakpoints) { {
+              '(max-width: 640px)' => {
+                tag_options: {
+                  sizes: 'calc(100vw - 20px)'
+                },
+                url_params: {
+                  h: 100,
+                }
+              },
+              '(max-width: 880px)' => {
+                url_params: {
+                  crop: 'right'
+                },
+                tag_options: {
+                  sizes: 'calc(100vw - 20px - 50%)'
+                }
+              },
+              '(min-width: 881px)' => {
+                url_params: {
+                  crop: 'left',
+                },
+                tag_options: {
+                  sizes: '430px'
+                }
+              }
+            } }
+
+        it 'raises error when no source is supplied' do
+          expect{
+            helper.ix_picture_tag(
+              'bertandernie.jpg',
+              tag_options: tag_options,
+              url_params: url_params,
+              breakpoints: breakpoints,
+            )
+          }.to raise_error(RuntimeError)
+        end
+
+        it "doesn't raise error when source is supplied" do
+          expect{
+            helper.ix_picture_tag(
+              'assets2.imgix.net',
+              'bertandernie.jpg',
+              tag_options: tag_options,
+              url_params: url_params,
+              breakpoints: breakpoints,
+            )
+          }.not_to raise_error
+        end
+      end
+
+      it 'raises error for unknown source' do
+        expect{
+          helper.ix_image_url("foo.bar", "image.jpg")
+        }.to raise_error(RuntimeError)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for generating URLs across multiple imgix sources. This PR also removes hostname replacement functionality.

### Multi-source support

#### Configuration
This PR adds support for following configuration:

- `:sources` a Hash of imgix source-secure_url_token key-value pairs. If the value for a source is `nil`, URLs generated for the corresponding source won't be secured. This option can't be used with `:source`.
- `:default_source` optionally specify a default source for generating URLs.

Example:

```ruby
Rails.application.configure do
  config.imgix = {
    sources: {
      "assets.imgix.net"  => "foobarbaz",
      "assets2.imgix.net" => nil,   # Will generate unsigned URLs
    },
    default_source: "assets.imgix.net"
  }
end
```

#### `ix_image_url`, `ix_image_tag`, `ix_picture_tag`

`source` optional argument is added to these helpers to support the following usage:

```erb
<%= ix_image_tag('assets2.imgix.net', '/unsplash/hotairballoon.jpg', tag_options: {}, url_params: {}, widhts: []) %>
<%= ix_image_url('assets2.imgix.net', '/users/1/avatar.png', { w: 400, h: 300 }) %>
<%= ix_picture_tag('assets2.imgix.net', 'bertandernie.jpg',
      tag_options: {},
      url_params: {},
      breakpoints: {
        '(max-width: 640px)' => {
          url_params: { h: 100 },
          tag_options: { sizes: 'calc(100vw - 20px)' }
        },
      }
   ) %>
```

If `source` is not supplied with these helpers, config specified `:default_source` or `:source` will be used.

#### Hostname removal

The existing implementation allowed the definition of `hostname_to_replace` configuration, supporting replacement of hosts in the original URL at run-time. It was discussed that this functionality is beyond the scope of this library and this PR removes the same.