### PR TITLE
Include `widths` option in picture tag

### DIFF
--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -12,8 +12,8 @@ module Imgix
         return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, widths: widths).render
       end
 
-      def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints:)
-        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints).render
+      def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints: {}, widths: [])
+        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints, widths: widths).render
       end
     end
   end


### PR DESCRIPTION
This PR adds proper support for the `widths` option in the `ix_picture_tag` helper, which allows users to override the set of standard widths applied to the `srcset` list for child `<source>` elements. This option's omission from this helper was an unintentional oversight.