### PR TITLE
Remove trailing widthless src in srcset generation

### DIFF
--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -27,8 +27,6 @@ protected
 
       "#{ix_image_url(@source, @path, srcset_url_params)} #{width}w"
     end.join(', ')
-
-    srcsetvalue += ", #{ix_image_url(@source, @path, srcset_url_params.except(:w, :h))}"
   end
 
   @@standard_widths = nil

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -203,7 +203,7 @@ describe Imgix::Rails do
 
         it 'generates the expected number of srcset values' do
           tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg")).children[0]
-          expect(tag.attribute('srcset').value.split(',').size).to eq(31)
+          expect(tag.attribute('srcset').value.split(',').size).to eq(30)
         end
 
         it 'generates the excpected number of srcset values with custom srcset-width-tolerance' do
@@ -226,11 +226,6 @@ describe Imgix::Rails do
           expect(Foo.new.get_standard_widths.size).to eq(7)
         end
 
-        it 'last value is a fallback image' do
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", url_params: {page: 3, w: 600, h: 300})).children[0]
-          expect(tag.attribute('srcset').value.split(',').last).not_to match("w=|h=")
-        end
-
         it 'correctly calculates `h` to maintain aspect ratio, when specified' do
           tag = Nokogiri::HTML.fragment(helper.ix_image_tag('presskit/imgix-presskit.pdf', url_params: {page: 3, w: 600, h: 300})).children[0]
           sources = tag.attribute('srcset').value.split(',')
@@ -249,7 +244,7 @@ describe Imgix::Rails do
           end
 
           it 'generates the expected number of srcset values' do
-            expect(tag.attribute('srcset').value.split(',').size).to eq(9)
+            expect(tag.attribute('srcset').value.split(',').size).to eq(8)
           end
         end
 
@@ -259,7 +254,7 @@ describe Imgix::Rails do
           end
 
           it 'generates the expected number of srcset values' do
-            expect(tag.attribute('srcset').value.split(',').size).to eq(2)
+            expect(tag.attribute('srcset').value.split(',').size).to eq(1)
           end
         end
       end


### PR DESCRIPTION
This PR fixes an issue found in #68, where our `srcset` generation was appending an extra widthless source to the end of its list, ostensibly as a "fallback image". This is incorrect: all URLs provided in a `srcset` must be accompanied a size description, and the "fallback image" in this scenario is provided by the element's `src` attribute.

This PR fixes #68.