### PR TITLE
Update bundler dev dependency to include new major version 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-before_install:
-  - rvm get head
 rvm:
   - 2.3.1
   - 2.2.5

--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "imgix", "~> 1.1", ">= 1.1.0"
 
-  spec.add_development_dependency "bundler", ">=1.9", "< 3.0"
+  spec.add_development_dependency "bundler", ">=1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-rails"

--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "imgix", "~> 1.1", ">= 1.1.0"
 
-  spec.add_development_dependency "bundler", ">=1.9", "< 3.0"
+  spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-rails"

--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "imgix", "~> 1.1", ">= 1.1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", ">=1.9", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
gemspec modified to allow bundler versions 1.9 through 3.0 (non inclusive) as a dev dependency. This way, users on 2.0 will not be forced to downgrade for development purposes.
Fixes bug #70 