### PR TITLE
chore(deps): upgrade imgix-rb to ~> 3.0

### DIFF
--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "imgix", "~> 1.1", ">= 1.1.0"
+  spec.add_runtime_dependency "imgix", "~> 3.0"
 
   spec.add_development_dependency "bundler", ">=1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -50,26 +50,14 @@ describe Imgix::Rails::UrlHelper do
       }.not_to raise_error
     end
 
-    describe 'support host/hosts' do
-      it 'sets host if source is a String' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: source
-          }
-        end
-
-        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+    it 'sets host if source is a String' do
+      Imgix::Rails.configure do |config|
+        config.imgix = {
+          source: source
+        }
       end
 
-      it 'sets hosts if source is an Array' do
-        Imgix::Rails.configure do |config|
-          config.imgix = {
-            source: [source]
-          }
-        end
-
-        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
-      end
+      expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
     end
 
     describe ':use_https' do


### PR DESCRIPTION
Resolves #75 
This PR updates the `imgix-rb` runtime dependency to use the latest major version. However, this does introduce a breaking change to this gem since the dependency no longer supports the use of the `hosts` argument used in domain sharding.