### PR TITLE
fix: deprecate resizing height when maintaining aspect ratio

### DIFF
--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -21,10 +21,6 @@ protected
     srcsetvalue = widths.map do |width|
       srcset_url_params[:w] = width
 
-      if url_params[:w].present? && url_params[:h].present?
-        srcset_url_params[:h] = (width * (url_params[:h].to_f / url_params[:w])).round
-      end
-
       "#{ix_image_url(@source, @path, srcset_url_params)} #{width}w"
     end.join(', ')
   end

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -226,18 +226,6 @@ describe Imgix::Rails do
           expect(Foo.new.get_standard_widths.size).to eq(7)
         end
 
-        it 'correctly calculates `h` to maintain aspect ratio, when specified' do
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag('presskit/imgix-presskit.pdf', url_params: {page: 3, w: 600, h: 300})).children[0]
-          sources = tag.attribute('srcset').value.split(',')
-          sources.each_with_index do |srcsetPair, i|
-            if i != (sources.size - 1)   # The last element doesn't have w, h
-              w = srcsetPair.match(/w=(\d+)/)[1].to_i
-              h = srcsetPair.match(/h=(\d+)/)[1].to_i
-              expect((w / 2.0).round).to eq(h)
-            end
-          end
-        end
-
         context 'with min_width' do
           let(:tag) do
             Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", tag_options: {min_width: 2560})).children[0]


### PR DESCRIPTION
This PR removes the logic in `ix_image_tag` responsible for resizing the `h` (height) parameter to maintain aspect ratio when building the `srcset` attribute. With the help of the [imgix aspect ratio parameter](https://blog.imgix.com/2019/07/17/aspect-ratio-parameter-makes-cropping-even-easier), users can now achieve the same effect with the inclusion of the `ar` parameter. Please note, the `ar` parameter should also be used with `fit=crop` to take effect. This should yield slightly better performance, code cleanliness, and bring the gem more in line with the imgix API.

----------
**Demo**
```ruby
<%= ix_image_tag('/demo.jpg', url_params: { w: 1000, ar: '2:1', fit: 'crop'} %>
```

Will produce an image cropped to the specified ratio:

|        | Example srcset URL                                                      |
|--------|-------------------------------------------------------------------------|
| Before | https://assets.imgix.net/examples/treefrog.jpg?w=1000&h=500&fit=crop    |
| After  | https://assets.imgix.net/examples/treefrog.jpg?w=1000&ar=2%3A1&fit=crop |