### PR TITLE
Add explicit ActionView requires

### DIFF
--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -1,5 +1,6 @@
 require "imgix/rails/tag"
 require "imgix/rails/image_tag"
+require "action_view"
 
 class Imgix::Rails::PictureTag < Imgix::Rails::Tag
   include ActionView::Context

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -1,4 +1,5 @@
 require "imgix/rails/url_helper"
+require "action_view"
 
 class Imgix::Rails::Tag
   include Imgix::Rails::UrlHelper


### PR DESCRIPTION
When doing some analysis on my Rails app (using https://github.com/nevir/Bumbler) errors were being thrown without explicitly requiring ActionView.  

Adding these lines fixed the errors, and should generally make testing imgix-rails in isolation more resilient.