### PR TITLE
feat: utilize Imgix::Path#to_srcset when constructing srcsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,17 @@ end
 
 The following configuration flags will be respected:
 
-- `:use_https` toggles the use of HTTPS. Defaults to `true`
-- `:source` a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
-- `:srcset_width_tolerance` an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `0.08` i.e. `8%`).
-- `:secure_url_token` an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
+- `use_https`: toggles the use of HTTPS. Defaults to `true`
+- `source`: a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
+- `srcset_width_tolerance`: an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `0.08` i.e. `8%`).
+- `secure_url_token`: an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
 
 #### Multi-source configuration
 
 In addition to the standard configuration flags, the following options can be used for multi-source support.
 
-- `:sources` a Hash of imgix source-secure_url_token key-value pairs. If the value for a source is `nil`, URLs generated for the corresponding source won't be secured. `:sources` and `:source` *cannot* be used together.
-- `:default_source` optionally specify a default source for generating URLs.
+- `sources`: a Hash of imgix source-secure_url_token key-value pairs. If the value for a source is `nil`, URLs generated for the corresponding source won't be secured. `sources` and `source` *cannot* be used together.
+- `default_source`: optionally specify a default source for generating URLs.
 
 Example:
 
@@ -86,21 +86,20 @@ end
 <a name="ix_image_tag"></a>
 ### ix_image_tag
 
-The `ix_image_tag` helper method makes it easy to pass parameters to imgix to handle resizing, cropping, etc. It also simplifies adding responsive imagery to your Rails app by automatically generating a `srcset` based on the parameters you pass. We talk a bit about using the `srcset` attribute in an application in the following blog post: [“Responsive Images with `srcset` and imgix.”](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix?_ga=utm_medium=referral&utm_source=sdk&utm_campaign=<lib>-readme).
+The `ix_image_tag` helper method makes it easy to pass parameters to imgix to handle resizing, cropping, etc. It also simplifies adding responsive imagery to your Rails app by automatically generating a `srcset` based on the parameters you pass. We talk a bit about using the `srcset` attribute in an application in the following blog post: [“Responsive Images with `srcset` and imgix.”](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix?_ga=utm_medium=referral&utm_source=sdk&utm_campaign=rails-readme).
 
-`ix_image_tag` generates `<img>` tags with a filled-out `srcset` attribute that leans on [imgix-rb](https://github.com/imgix/imgix-rb#fixed-image-rendering) to do the hard work. It also makes a variety of options available for customizing how the `srcset` is generated. For example, if you already know the minimum or maximum number of physical pixels that this image will need to be displayed at, you can pass the `min_width` and/or `max_width` options. This will result in a smaller, more tailored `srcset`.
+`ix_image_tag` generates `<img>` tags with a filled-out `srcset` attribute that leans on [imgix-rb](https://github.com/imgix/imgix-rb) to do the hard work. It also makes a variety of options available for customizing how the `srcset` is generated. For example, if you already know the minimum or maximum number of physical pixels that this image will need to be displayed at, you can pass the `min_width` and/or `max_width` options. This will result in a smaller, more tailored `srcset`.
 
 `ix_image_tag` takes the following arguments:
 
 * `source`: An optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
 * `path`: The path or URL of the image to display.
-* `tag_options`: Any options to apply to the generated `img` element. This is useful for adding class names, alt tags, etc.
+* `tag_options`: HTML attributes to apply to the generated `img` element. This is useful for adding class names, alt tags, etc.
 * `url_params`: The imgix URL parameters to apply to this image. These will be applied to each URL in the `srcset` attribute, as well as the fallback `src` attribute.
 * `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:
-  
   * [`widths`](https://github.com/imgix/imgix-rb#custom-widths): An array of exact widths that `srcset` pairs will be generated with.
-  * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with.
-  * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with.
+  * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with. Will be ignored if `widths` are provided.
+  * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with. Will be ignored if `widths` are provided.
   * [`disable_variable_quality`](https://github.com/imgix/imgix-rb#variable-qualities): Pass `true` to disable variable quality parameters when generating a `srcset` ([fixed-images only](https://github.com/imgix/imgix-rails#fixed-image-rendering)). In addition, imgix-rails will respect an overriding `q` (quality) parameter if one is provided through `url_params`.
 
 ```erb
@@ -148,14 +147,14 @@ Then rendering the portrait in your application is very easy:
 If you already know all the exact widths you need images for, you can specify that by passing the `widths` option as an array. In this case, imgix-rails will only generate `srcset` pairs for the specified `widths`.
 
 ```erb
-<%= ix_image_tag('/unsplash/hotairballoon.jpg', srcset_options: { widths: [320, 640, 960, 1280] }, url_params: { w: 300, h: 500, fit: 'crop', crop: 'right'}, tag_options: { alt: 'A hot air balloon on a sunny day' }) %>
+<%= ix_image_tag('/unsplash/hotairballoon.jpg', srcset_options: { widths: [320, 640, 960, 1280] }, tag_options: { alt: 'A hot air balloon on a sunny day' }) %>
 ```
 
 #### Fixed image rendering
 
 In cases where enough information is provided about an image's dimensions, `ix_image_tag` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `ix_image_tag` with either a width or the height and aspect ratio (along with `fit=crop`, typically) provided, a different srcset will be generated for a fixed-size image instead.
 
-```rb
+```erb
 <%= ix_image_tag('/unsplash/hotairballoon.jpg', url_params: {w: 1000}) %>
 ```
 
@@ -168,6 +167,8 @@ https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=3&amp;q=
 https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=4&amp;q=23 4x,
 https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=5&amp;q=20 5x" sizes="100vw" src="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000">
 ```
+
+Fixed image rendering will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a `srcset`. This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality?_ga=utm_medium=referral&utm_source=sdk&utm_campaign=rails-readme). This behavior will respect any overriding `q` value passed in via `url_params` and can be disabled altogether with `srcset_options: { disable_variable_quality: true }`.
 
 <a name="ix_picture_tag"></a>
 ### ix_picture_tag
@@ -182,7 +183,6 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 * `url_params`: Default imgix options. These will be used to generate a fallback `img` tag for older browsers, and used in each `source` unless overridden by `breakpoints`.
 * `breakpoints`: A hash describing the variants. Each key must be a media query (e.g. `(max-width: 880px)`), and each value must be a hash of parameter overrides for that media query. A `source` element will be generated for each breakpoint specified.
 * `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:
-  
   * [`widths`](https://github.com/imgix/imgix-rb#custom-widths): An array of exact widths that `srcset` pairs will be generated with.
   * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with.
   * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with.

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 * `breakpoints`: A hash describing the variants. Each key must be a media query (e.g. `(max-width: 880px)`), and each value must be a hash of parameter overrides for that media query. A `source` element will be generated for each breakpoint specified.
 * `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:
   * [`widths`](https://github.com/imgix/imgix-rb#custom-widths): An array of exact widths that `srcset` pairs will be generated with.
-  * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with.
-  * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with.
+  * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with. Will be ignored if `widths` are provided.
+  * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with. Will be ignored if `widths` are provided.
   * [`disable_variable_quality`](https://github.com/imgix/imgix-rb#variable-qualities): Pass `true` to disable variable quality parameters when generating a `srcset` ([fixed-images only](https://github.com/imgix/imgix-rails#fixed-image-rendering)). In addition, imgix-rails will respect an overriding `q` (quality) parameter if one is provided through `url_params`.
 
 ```erb

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following configuration flags will be respected:
 
 - `:use_https` toggles the use of HTTPS. Defaults to `true`
 - `:source` a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
-- `:srcset_width_tolerance` an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `.08` i.e. `8%`).
+- `:srcset_width_tolerance` an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `0.08` i.e. `8%`).
 - `:secure_url_token` an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
 
 #### Multi-source configuration
@@ -86,16 +86,22 @@ end
 <a name="ix_image_tag"></a>
 ### ix_image_tag
 
-The `ix_image_tag` helper method makes it easy to pass parameters to imgix to handle resizing, cropping, etc. It also simplifies adding responsive imagery to your Rails app by automatically generating a `srcset` based on the parameters you pass. We talk a bit about using the `srcset` attribute in an application in the following blog post: [“Responsive Images with `srcset` and imgix.”](https://blog.imgix.com/2015/08/18/responsive-images-with-srcset-imgix.html).
+The `ix_image_tag` helper method makes it easy to pass parameters to imgix to handle resizing, cropping, etc. It also simplifies adding responsive imagery to your Rails app by automatically generating a `srcset` based on the parameters you pass. We talk a bit about using the `srcset` attribute in an application in the following blog post: [“Responsive Images with `srcset` and imgix.”](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix?_ga=utm_medium=referral&utm_source=sdk&utm_campaign=<lib>-readme).
 
-`ix_image_tag` generates `<img>` tags with a filled-out `srcset` attribute that leans on imgix to do the hard work. If you already know the minimum or maximum number of physical pixels that this image will need to be displayed at, you can pass the `min_width` and/or `max_width` options. This will result in a smaller, more tailored `srcset`.
+`ix_image_tag` generates `<img>` tags with a filled-out `srcset` attribute that leans on [imgix-rb](https://github.com/imgix/imgix-rb#fixed-image-rendering) to do the hard work. It also makes a variety of options available for customizing how the `srcset` is generated. For example, if you already know the minimum or maximum number of physical pixels that this image will need to be displayed at, you can pass the `min_width` and/or `max_width` options. This will result in a smaller, more tailored `srcset`.
 
 `ix_image_tag` takes the following arguments:
 
-* `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
+* `source`: An optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
 * `path`: The path or URL of the image to display.
-* `tag_options`: Any options to apply to the generated `img` element. This is useful for adding class names, etc.
+* `tag_options`: Any options to apply to the generated `img` element. This is useful for adding class names, alt tags, etc.
 * `url_params`: The imgix URL parameters to apply to this image. These will be applied to each URL in the `srcset` attribute, as well as the fallback `src` attribute.
+* `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:
+  
+  * [`widths`](https://github.com/imgix/imgix-rb#custom-widths): An array of exact widths that `srcset` pairs will be generated with.
+  * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with.
+  * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with.
+  * [`disable_variable_quality`](https://github.com/imgix/imgix-rb#variable-qualities): Pass `true` to disable variable quality parameters when generating a `srcset` ([fixed-images only](https://github.com/imgix/imgix-rails#fixed-image-rendering)). In addition, imgix-rails will respect an overriding `q` (quality) parameter if one is provided through `url_params`.
 
 ```erb
 <%= ix_image_tag('/unsplash/hotairballoon.jpg', url_params: { w: 300, h: 500, fit: 'crop', crop: 'right'}, tag_options: { alt: 'A hot air balloon on a sunny day' }) %>
@@ -142,9 +148,26 @@ Then rendering the portrait in your application is very easy:
 If you already know all the exact widths you need images for, you can specify that by passing the `widths` option as an array. In this case, imgix-rails will only generate `srcset` pairs for the specified `widths`.
 
 ```erb
-<%= ix_image_tag('/unsplash/hotairballoon.jpg', widths: [320, 640, 960, 1280], url_params: { w: 300, h: 500, fit: 'crop', crop: 'right'}, tag_options: { alt: 'A hot air balloon on a sunny day' }) %>
+<%= ix_image_tag('/unsplash/hotairballoon.jpg', srcset_options: { widths: [320, 640, 960, 1280] }, url_params: { w: 300, h: 500, fit: 'crop', crop: 'right'}, tag_options: { alt: 'A hot air balloon on a sunny day' }) %>
 ```
 
+#### Fixed image rendering
+
+In cases where enough information is provided about an image's dimensions, `ix_image_tag` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `ix_image_tag` with either a width or the height and aspect ratio (along with `fit=crop`, typically) provided, a different srcset will be generated for a fixed-size image instead.
+
+```rb
+<%= ix_image_tag('/unsplash/hotairballoon.jpg', url_params: {w: 1000}) %>
+```
+
+Will render the following HTML:
+
+```html
+<img srcset="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=1&amp;q=75 1x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=2&amp;q=50 2x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=3&amp;q=35 3x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=4&amp;q=23 4x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=5&amp;q=20 5x" sizes="100vw" src="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000">
+```
 
 <a name="ix_picture_tag"></a>
 ### ix_picture_tag
@@ -158,6 +181,12 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 * `tag_options`: Any options to apply to the parent `picture` element. This is useful for adding class names, etc.
 * `url_params`: Default imgix options. These will be used to generate a fallback `img` tag for older browsers, and used in each `source` unless overridden by `breakpoints`.
 * `breakpoints`: A hash describing the variants. Each key must be a media query (e.g. `(max-width: 880px)`), and each value must be a hash of parameter overrides for that media query. A `source` element will be generated for each breakpoint specified.
+* `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:
+  
+  * [`widths`](https://github.com/imgix/imgix-rb#custom-widths): An array of exact widths that `srcset` pairs will be generated with.
+  * [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with.
+  * [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with.
+  * [`disable_variable_quality`](https://github.com/imgix/imgix-rb#variable-qualities): Pass `true` to disable variable quality parameters when generating a `srcset` ([fixed-images only](https://github.com/imgix/imgix-rails#fixed-image-rendering)). In addition, imgix-rails will respect an overriding `q` (quality) parameter if one is provided through `url_params`.
 
 ```erb
 <%= ix_picture_tag('bertandernie.jpg',

--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -10,7 +10,7 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
     @tag_options = tag_options
     @url_params = url_params
     @breakpoints = breakpoints
-    @widths = widths.length > 0 ? widths : target_widths
+    @widths = widths.length > 0 ? widths : []
   end
 
   def render

--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -16,20 +16,26 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
   def render
     content_tag(:picture, @tag_options) do
       @breakpoints.each do |media, opts|
+        validate_opts(opts)
+
         source_tag_opts = opts[:tag_options] || {}
         source_tag_url_params = opts[:url_params] || {}
-        widths = opts[:widths]
-        unsupported_opts = opts.except(:tag_options, :url_params, :widths)
-        if unsupported_opts.length > 0
-          raise "'#{unsupported_opts.keys.join("', '")}' key(s) not supported; use tag_options, url_params, widths."
-        end
-        srcset_options = {widths: widths}
+        srcset_options = opts[:srcset_options] || {}
         source_tag_opts[:media] ||= media
         source_tag_opts[:srcset] ||= srcset(url_params: @url_params.clone.merge(source_tag_url_params), srcset_options: srcset_options)
+
         concat(content_tag(:source, nil, source_tag_opts))
       end
 
-      concat Imgix::Rails::ImageTag.new(@path, source: @source, url_params: @url_params).render
+      concat Imgix::Rails::ImageTag.new(@path, source: @source, url_params: @url_params, srcset_options: @srcset_options).render
     end
   end
+
+  private
+    def validate_opts(opts = {})
+      unsupported_opts = opts.except(:tag_options, :url_params, :srcset_options)
+        if unsupported_opts.length > 0
+          raise "'#{unsupported_opts.keys.join("', '")}' key(s) not supported; use tag_options, url_params, srcset_options."
+        end
+    end
 end

--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -4,13 +4,13 @@ require "imgix/rails/image_tag"
 class Imgix::Rails::PictureTag < Imgix::Rails::Tag
   include ActionView::Context
 
-  def initialize(path, source: nil, tag_options: {}, url_params: {}, breakpoints: {}, widths: [])
+  def initialize(path, source: nil, tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})
     @path = path
     @source = source
     @tag_options = tag_options
     @url_params = url_params
     @breakpoints = breakpoints
-    @widths = widths.length > 0 ? widths : []
+    @srcset_options = srcset_options
   end
 
   def render
@@ -23,9 +23,9 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
         if unsupported_opts.length > 0
           raise "'#{unsupported_opts.keys.join("', '")}' key(s) not supported; use tag_options, url_params, widths."
         end
-
+        srcset_options = {widths: widths}
         source_tag_opts[:media] ||= media
-        source_tag_opts[:srcset] ||= srcset(url_params: @url_params.clone.merge(source_tag_url_params), widths: widths)
+        source_tag_opts[:srcset] ||= srcset(url_params: @url_params.clone.merge(source_tag_url_params), srcset_options: srcset_options)
         concat(content_tag(:source, nil, source_tag_opts))
       end
 

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -4,22 +4,25 @@ class Imgix::Rails::Tag
   include Imgix::Rails::UrlHelper
   include ActionView::Helpers
 
-  def initialize(path, source: nil, tag_options: {}, url_params: {}, widths: [])
+  def initialize(path, source: nil, tag_options: {}, url_params: {}, srcset_options: {})
     @path = path
     @source = source
     @tag_options = tag_options
     @url_params = url_params
-    @widths = widths
+    @srcset_options = srcset_options
   end
 
 protected
 
-  def srcset(source: @source, path: @path, url_params: @url_params, widths: @widths, tag_options: @tag_options)
+  def srcset(source: @source, path: @path, url_params: @url_params, srcset_options: @srcset_options, tag_options: @tag_options)
     params = url_params.clone
+
     width_tolerance = ::Imgix::Rails.config.imgix[:srcset_width_tolerance]
-    min_width = @tag_options[:min_width]
-    max_width = @tag_options[:max_width]
-    options = { widths: @widths, width_tolerance: width_tolerance, min_width: min_width, max_width: max_width}
+    min_width = @srcset_options[:min_width]
+    max_width = @srcset_options[:max_width]
+    widths = @srcset_options[:widths]
+    disable_variable_quality = @srcset_options[:disable_variable_quality]
+    options = { widths: widths, width_tolerance: width_tolerance, min_width: min_width, max_width: max_width, disable_variable_quality: disable_variable_quality}
 
     ix_image_srcset(@source, @path, params, options)
   end

--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -10,28 +10,65 @@ module Imgix
         when 1
           path = args[0]
           source = nil
-          options = {}
+          params = {}
         when 2
           if args[0].is_a?(String) && args[1].is_a?(Hash)
             source = nil
             path = args[0]
-            options = args[1]
+            params = args[1]
           elsif args[0].is_a?(String) && args[1].is_a?(String)
             source = args[0]
             path = args[1]
-            options = {}
+            params = {}
           else
-            raise RuntimeError.new("path and source must be of type String; options must be of type Hash")
+            raise RuntimeError.new("path and source must be of type String; params must be of type Hash")
           end
         when 3
           source = args[0]
           path = args[1]
-          options = args[2]
+          params = args[2]
         else
           raise RuntimeError.new('path missing')
         end
 
-        imgix_client(source).path(path).to_url(options).html_safe
+        imgix_client(source).path(path).to_url(params).html_safe
+      end
+
+      protected
+
+      def ix_image_srcset(*args)
+        validate_configuration!
+
+        case args.size
+        when 1
+          path = args[0]
+          source = nil
+          params = {}
+        when 2
+          if args[0].is_a?(String) && args[1].is_a?(Hash)
+            source = nil
+            path = args[0]
+            params = args[1]
+          elsif args[0].is_a?(String) && args[1].is_a?(String)
+            source = args[0]
+            path = args[1]
+            params = {}
+          else
+            raise RuntimeError.new("path and source must be of type String; params must be of type Hash")
+          end
+        when 3
+          source = args[0]
+          path = args[1]
+          params = args[2]
+        when 4
+          source = args[0]
+          path = args[1]
+          params = args[2]
+          options = args[3]
+        else
+          raise RuntimeError.new('path missing')
+        end
+        imgix_client(source).path(path).to_srcset(options: options, **params).html_safe
       end
 
       private

--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -8,12 +8,12 @@ module Imgix
     module ViewHelper
       include UrlHelper
 
-      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, widths: [])
-        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, widths: widths).render
+      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, srcset_options: {})
+        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, srcset_options: srcset_options).render
       end
 
-      def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints: {}, widths: [])
-        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints, widths: widths).render
+      def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})
+        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints, srcset_options: srcset_options).render
       end
     end
   end

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -284,12 +284,11 @@ describe Imgix::Rails do
 
           context 'widths' do
             it 'allows explicitly specifying desired widths' do
-              tag = Nokogiri::HTML.fragment(helper.ix_image_tag('image.jpg', url_params: {w: 400, h: 300})).children[0]
-              expect(tag.attribute('srcset').value).to include('1x')
-              expect(tag.attribute('srcset').value).to include('2x')
-              expect(tag.attribute('srcset').value).to include('3x')
-              expect(tag.attribute('srcset').value).to include('4x')
-              expect(tag.attribute('srcset').value).to include('5x')
+              tag = Nokogiri::HTML.fragment(helper.ix_image_tag('image.jpg', srcset_options: {widths: [100, 500, 800, 1200]})).children[0]
+              expect(tag.attribute('srcset').value).to include('100w')
+              expect(tag.attribute('srcset').value).to include('500w')
+              expect(tag.attribute('srcset').value).to include('800w')
+              expect(tag.attribute('srcset').value).to include('1200w')
             end
 
             it 'does not include `widths` as an attribute in the generated tag' do

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -180,10 +180,12 @@ describe Imgix::Rails do
       end
 
       it 'allows explicitly specifying desired widths' do
-        tag = Nokogiri::HTML.fragment(helper.ix_image_tag('image.jpg', widths: [10, 20, 30], url_params: {w: 400, h: 300})).children[0]
-        expect(tag.attribute('srcset').value).to include('10w')
-        expect(tag.attribute('srcset').value).to include('20w')
-        expect(tag.attribute('srcset').value).to include('30w')
+        tag = Nokogiri::HTML.fragment(helper.ix_image_tag('image.jpg', url_params: {w: 400, h: 300})).children[0]
+        expect(tag.attribute('srcset').value).to include('1x')
+        expect(tag.attribute('srcset').value).to include('2x')
+        expect(tag.attribute('srcset').value).to include('3x')
+        expect(tag.attribute('srcset').value).to include('4x')
+        expect(tag.attribute('srcset').value).to include('5x')
       end
 
       it 'does not include `widths` as an attribute in the generated tag' do
@@ -230,7 +232,7 @@ describe Imgix::Rails do
 
         it 'generates the expected number of srcset values' do
           tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg")).children[0]
-          expect(tag.attribute('srcset').value.split(',').size).to eq(30)
+          expect(tag.attribute('srcset').value.split(',').size).to eq(31)
         end
 
         it 'generates the excpected number of srcset values with custom srcset-width-tolerance' do
@@ -241,16 +243,9 @@ describe Imgix::Rails do
             }
           end
 
-          class Foo < Imgix::Rails::Tag
-            def initialize
-            end
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg")).children[0]
 
-            def get_standard_widths
-              compute_standard_widths
-            end
-          end
-
-          expect(Foo.new.get_standard_widths.size).to eq(7)
+          expect(tag.attribute('srcset').value.split(',').size).to eq(8)
         end
 
         context 'with min_width' do
@@ -259,7 +254,7 @@ describe Imgix::Rails do
           end
 
           it 'generates the expected number of srcset values' do
-            expect(tag.attribute('srcset').value.split(',').size).to eq(8)
+            expect(tag.attribute('srcset').value.split(',').size).to eq(9)
           end
         end
 
@@ -269,6 +264,7 @@ describe Imgix::Rails do
           end
 
           it 'generates the expected number of srcset values' do
+            puts tag
             expect(tag.attribute('srcset').value.split(',').size).to eq(1)
           end
         end


### PR DESCRIPTION
This PR offloads all of heavy lifting when building `srcset` attributes onto the imgix-rb gem, which has recently received a massive upgrade to support various forms of `srcset` building/customization. These changes only apply to `ix_image_tag` and `ix_picture_tag`:
-  Eliminates the need to calculate/filter `standard_widths`, which are now just generated by the underlying imgix-rb gem. This yields a much cleaner codebase.
- Includes the addition of [fixed-sized srcsets](https://github.com/imgix/imgix-rb#fixed-image-rendering) which allows users to serve the same size image at different resolutions. 
	- This also includes a handy new feature called [variable qualities](https://github.com/imgix/imgix-rb#variable-qualities) which can help maximize the quality to image weight ratio.
- Extracts all srcset-related modifiers into their own `srcet_options` (resolves #82). This provides a clearer experience when fine-tuning the `srcset` value generated by this gem. The options currently include:
	- [`widths`](https://github.com/imgix/imgix-rb#custom-widths): An array of exact widths that `srcset` pairs will be generated with.
  	- [`min_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The minimum width that `srcset` pairs will be generated with.
  	- [`max_width`](https://github.com/imgix/imgix-rb#minimum-and-maximum-width-ranges): The maximum width that `srcset` pairs will be generated with.
  	- [`disable_variable_quality`](https://github.com/imgix/imgix-rb#variable-qualities): Pass `true` to disable variable quality parameters when generating a `srcset` (for fixed-images only). In addition, imgix-rails will respect an overriding `q` (quality) parameter if one is provided through `url_params`.