### PR TITLE
docs: add project metadata to gemspec

### DIFF
--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -14,6 +14,12 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Makes integrating imgix into your Rails app easier. It builds on imgix-rb to offer a few Rails-specific interfaces. Please see https://github.com/imgix/imgix-rails for more details.}
   spec.homepage      = "https://github.com/imgix/imgix-rails"
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/imgix/imgix-rails/issues',
+    'changelog_uri'     => 'https://github.com/imgix/imgix-rails/blob/master/CHANGELOG.md',
+    'documentation_uri' => "https://www.rubydoc.info/gems/imgix-rails/#{spec.version}",
+    'source_code_uri'   => "https://github.com/imgix/imgix-rails/tree/v#{spec.version}"
+  }
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
This PR adds [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. The project metadata allows users to more easily access the source code, raise issues, and view the changelog directly from the [imgix-rails page](https://rubygems.org/gems/imgix-rails) on rubygems. These fields will also be accessible via the rubygems API.