### PR TITLE
docs: add description and tests for include_library_param option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following configuration flags will be respected:
 - `source`: a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
 - `srcset_width_tolerance`: an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `0.08` i.e. `8%`).
 - `secure_url_token`: an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
+- `include_library_param`: toggles the use of `ixlib` params. Defaults to `true`. Check [here](https://github.com/imgix/imgix-rb#what-is-the-ixlib-param-on-every-request) for detail.
 
 #### Multi-source configuration
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following configuration flags will be respected:
 - `source`: a String or Array that specifies the imgix Source address. Should be in the form of `"assets.imgix.net"`.
 - `srcset_width_tolerance`: an optional numeric value determining the maximum tolerance allowable, between the downloaded dimensions and rendered dimensions of the image (default `0.08` i.e. `8%`).
 - `secure_url_token`: an optional secure URL token found in your dashboard (https://dashboard.imgix.com) used for signing requests
-- `include_library_param`: toggles the use of `ixlib` params. Defaults to `true`. Check [here](https://github.com/imgix/imgix-rb#what-is-the-ixlib-param-on-every-request) for detail.
+- `include_library_param`: toggles the inclusion of the [`ixlib` parameter](https://github.com/imgix/imgix-rb#what-is-the-ixlib-param-on-every-request). Defaults to `true`.
 
 #### Multi-source configuration
 

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -82,5 +82,28 @@ describe Imgix::Rails::UrlHelper do
         expect(url_helper.ix_image_url("image.jpg")).to eq  "http://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
       end
     end
+  
+    describe ':include_library_param' do
+      it 'ixlib parameter exists by default' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source
+          }
+        end
+
+        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+      end
+
+      it 'respects the :include_library_param flag' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source,
+            include_library_param: false
+          }
+        end
+
+        expect(url_helper.ix_image_url("image.jpg")).to eq  "https://assets.imgix.net/image.jpg"
+      end
+    end
   end
 end

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -115,6 +115,31 @@ describe Imgix::Rails do
         expect(tag.attribute('src').value).to eq("http://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}")
       end
     end
+
+    describe ':include_library_param' do
+      it 'ixlib parameter exists by default' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source
+          }
+        end
+
+        tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg")).children[0]
+        expect(tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}")
+      end
+
+      it 'respects the :include_library_param flag' do
+        Imgix::Rails.configure do |config|
+          config.imgix = {
+            source: source,
+            include_library_param: false
+          }
+        end
+
+        tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg")).children[0]
+        expect(tag.attribute('src').value).to eq("https://assets.imgix.net/image.jpg")
+      end
+    end
   end
 
   describe Imgix::Rails::ViewHelper do


### PR DESCRIPTION
First of all, thank you for fantastic service & gem!

This PR adds document and test for `include_library_param` option.

This option configurable and useful, but that seems hasn't been documented and tested yet.