### PR TITLE
fix: replace opts[:host] with opts[:domain] to suppress deprecated warnings

### DIFF
--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -112,7 +112,7 @@ module Imgix
         }
 
         if imgix[:source].is_a?(String)
-          opts[:host] = imgix[:source]
+          opts[:domain] = imgix[:source]
         end
 
         if imgix.has_key?(:include_library_param)
@@ -127,7 +127,7 @@ module Imgix
         @imgix_clients = {}
 
         sources.map do |source, token|
-          opts[:host] = source
+          opts[:domain] = source
           opts[:secure_url_token] = token
           @imgix_clients[source] = ::Imgix::Client.new(opts)
         end

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -50,7 +50,7 @@ describe Imgix::Rails::UrlHelper do
       }.not_to raise_error
     end
 
-    it 'sets host if source is a String' do
+    it 'sets domain if source is a String' do
       Imgix::Rails.configure do |config|
         config.imgix = {
           source: source


### PR DESCRIPTION
The purpose of this PR is to resolve deprecation warnings being thrown
as a result of using `imgix-rb` version `3.3.0`, see [here](https://github.com/imgix/imgix-rb/pull/76).

