### PR TITLE
fix: move tag_options from picture element to img element in ix_picture_tag

### DIFF
--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -15,7 +15,7 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
   end
 
   def render
-    content_tag(:picture, @tag_options) do
+    content_tag(:picture) do
       @breakpoints.each do |media, opts|
         validate_opts(opts)
 
@@ -28,7 +28,7 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
         concat(content_tag(:source, nil, source_tag_opts))
       end
 
-      concat Imgix::Rails::ImageTag.new(@path, source: @source, url_params: @url_params, srcset_options: @srcset_options).render
+      concat Imgix::Rails::ImageTag.new(@path, source: @source, url_params: @url_params, srcset_options: @srcset_options, tag_options: @tag_options).render
     end
   end
 

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -52,14 +52,14 @@ describe Imgix::Rails do
 
     it 'expects either a :source or :sources, but not both' do
       Imgix::Rails.configure { |config| config.imgix = { source: "domain1", sources: "domain2" } }
-      
+
       expect{
         helper.ix_image_url("assets.png")
       }.to raise_error(Imgix::Rails::ConfigurationError, "Exactly one of :source, :sources is required")
     end
 
     it 'expects :sources to be a hash' do
-      Imgix::Rails.configure { |config| 
+      Imgix::Rails.configure { |config|
         config.imgix = {
           sources: 1
         }
@@ -382,8 +382,8 @@ describe Imgix::Rails do
         expect(tag.name).to eq('picture')
       end
 
-      it 'passes through options to the `picture`' do
-        expect(tag.attribute('class').value).to eq('a-picture-tag')
+      it 'passes through tag options to the contained `img`' do
+        expect(tag.css('img').attribute('class').value).to eq('a-picture-tag')
       end
 
       it 'generates the specified number of `source` children' do
@@ -501,7 +501,7 @@ describe Imgix::Rails do
                 }
               }
             )
-    
+
             Nokogiri::HTML.fragment(picture_tag).children[0]
           end
 
@@ -536,7 +536,7 @@ describe Imgix::Rails do
                 }
               }
             )
-    
+
             Nokogiri::HTML.fragment(picture_tag).children[0]
           end
 
@@ -571,7 +571,7 @@ describe Imgix::Rails do
                 }
               }
             )
-    
+
             Nokogiri::HTML.fragment(picture_tag).children[0]
           end
 
@@ -757,7 +757,7 @@ describe Imgix::Rails do
           end
         end
 
-        describe 'passes through options to the `picture`' do
+        describe 'passes through tag options to the contained `img`' do
           it 'with no source supplied' do
             picture_tag = helper.ix_picture_tag(
               'bertandernie.jpg',
@@ -766,7 +766,7 @@ describe Imgix::Rails do
               breakpoints: breakpoints,
             )
             tag = Nokogiri::HTML.fragment(picture_tag).children[0]
-            expect(tag.attribute('class').value).to eq('a-picture-tag')
+            expect(tag.css('img').attribute('class').value).to eq('a-picture-tag')
           end
 
           it 'with explicit source supplied' do
@@ -781,7 +781,7 @@ describe Imgix::Rails do
             url = tag.css('img')[0].attribute('src').value
 
             # tag_options
-            expect(tag.attribute('class').value).to eq('a-picture-tag')
+            expect(tag.css('img').attribute('class').value).to eq('a-picture-tag')
 
             # url_params
             expect(url).to include("w=300")


### PR DESCRIPTION
# Description

Currently, the `tag_options` param is being applied to the `<picture>` element when using `ix_picture_tag`. This makes it difficult to actually style the picture element, especially with frameworks like Tailwind, because the browser renders the matching source within the `<img>` element. This PR moves `tag_options` so that it is applied to the img tag instead of the picture tag.

A more flexible implementation would allow setting tag_options on both the picture element and the img element. Feel free to update if desired. I didn't want to mess with the method signature.

## Checklist: Bug Fix

- [ ] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [ ] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Update or add any necessary API documentation
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix

## Steps to Test

One would expect this to center the image, but it does not because it's being applied to the picture element instead of the contained img element.

```css
.mx-auto {
  margin-left: auto;
  margin-right: auto;
}
```

```erb
<%= ix_picture_tag('image.jpg',
  tag_options: { class: 'mx-auto' },
  url_params: { w: 150, h: 150 },
  breakpoints: {
    '(min-width: 768px)' => {
      url_params: { w: 200, h: 200 }
    }
  })
%>
```
