### PR TITLE
chore: update to imgix 4.0

### DIFF
--- a/imgix-rails.gemspec
+++ b/imgix-rails.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "imgix", "~> 3.0"
+  spec.add_runtime_dependency "imgix", "~> 4.0"
 
   spec.add_development_dependency "bundler", ">=1.9"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
The purpose of this PR is to update the `imgix` version to `~> 4.0`.