### PR TITLE
Add support for lazy image loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Fixed image rendering will automatically append a variable `q` parameter mapped 
 
 #### Lazy loading
 
-If you'd like to lazy load images, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use imgix-rails with lazysizes, you can simply add a `lazy` attribute with `true`:
+If you'd like to lazy load images, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use imgix-rails with lazysizes, you can add a `lazy` attribute and pass it a value `true`:
 
 ```erb
 <%= ix_image_tag('image.jpg', lazy: true, url_params: {w: 1000}) %>
@@ -224,7 +224,7 @@ data-src="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000"
 src="/loading.gif">
 ```
 
-You can use Imgix for the loading image as long as you use `ix_image_url`:
+You can use an image served through imgix for the loading image as long as you use `ix_image_url`:
 
 ```erb
 <%= ix_image_tag('image.jpg', lazy: ix_image_url('loading.gif', {w: 1000 }), url_params: {w: 1000}) %>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     - [Multi-source configuration](#multi-source-configuration)
   - [`ix_image_tag`](#iximagetag)
     - [Fixed image rendering](#fixed-image-rendering)
+    - [Lazy Loading](#lazy-loading)
   - [`ix_picture_tag`](#ixpicturetag)
   - [`ix_image_url`](#iximageurl)
     - [Usage in Model](#usage-in-model)
@@ -178,6 +179,69 @@ https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=5&amp;q=
 ```
 
 Fixed image rendering will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a `srcset`. This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality?_ga=utm_medium=referral&utm_source=sdk&utm_campaign=rails-readme). This behavior will respect any overriding `q` value passed in via `url_params` and can be disabled altogether with `srcset_options: { disable_variable_quality: true }`.
+
+#### Lazy loading
+
+If you'd like to lazy load images, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use imgix-rails with lazysizes, you can simply add a `lazy` attribute with `true`:
+
+```erb
+<%= ix_image_tag('image.jpg', lazy: true, url_params: {w: 1000}) %>
+```
+
+Will render the following HTML:
+
+```html
+<img data-srcset="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=1&amp;q=75 1x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=2&amp;q=50 2x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=3&amp;q=35 3x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=4&amp;q=23 4x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=5&amp;q=20 5x"
+sizes="100vw"
+data-src="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000"
+src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=">
+```
+
+A small 1x1 GIF will be shown while the image is loading. Once the image
+has been loaded in the background, provided you have required lazysizes in your
+application, the correct image will be loaded.
+
+You can optionally pass an image to be used as the loading image:
+
+```erb
+<%= ix_image_tag('image.jpg', lazy: 'loading.gif', url_params: {w: 1000}) %>
+```
+
+This will render the following HTML:
+
+```html
+<img data-srcset="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=1&amp;q=75 1x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=2&amp;q=50 2x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=3&amp;q=35 3x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=4&amp;q=23 4x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=5&amp;q=20 5x"
+sizes="100vw"
+data-src="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000"
+src="/loading.gif">
+```
+
+You can use Imgix for the loading image as long as you use `ix_image_url`:
+
+```erb
+<%= ix_image_tag('image.jpg', lazy: ix_image_url('loading.gif', {w: 1000 }), url_params: {w: 1000}) %>
+```
+
+Then the result would be:
+
+```html
+<img data-srcset="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=1&amp;q=75 1x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=2&amp;q=50 2x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=3&amp;q=35 3x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=4&amp;q=23 4x,
+https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000&amp;dpr=5&amp;q=20 5x"
+sizes="100vw"
+data-src="https://assets.imgix.net/image.jpg?ixlib=rails-3.0.2&amp;w=1000"
+src="https://assets.imgix.net/loading.gif?ixlib=rails-3.0.2&amp;w=1000">
+```
 
 ### `ix_picture_tag`
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The `ix_image_tag` helper method makes it easy to pass parameters to imgix to ha
 
 * `source`: An optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
 * `path`: The path or URL of the image to display.
+* `lazy`: If true, attributes will be generated in the `data` attribute hash. A 1-pixel GIF will be displayed until image has been loaded. You can optionally pass an URL to `lazy` for the image which will be used i.e. your own loading GIF. You need to bring your JS lib to support this like [lazysizes](https://github.com/aFarkas/lazysizes).
 * `tag_options`: HTML attributes to apply to the generated `img` element. This is useful for adding class names, alt tags, etc.
 * `url_params`: The imgix URL parameters to apply to this image. These will be applied to each URL in the `srcset` attribute, as well as the fallback `src` attribute.
 * `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:

--- a/lib/imgix/rails/image_tag.rb
+++ b/lib/imgix/rails/image_tag.rb
@@ -5,26 +5,26 @@ class Imgix::Rails::ImageTag < Imgix::Rails::Tag
   def render
     url = ix_image_url(@source, @path, @url_params)
 
-    if @lazy
-      @tag_options[:data] ||= {}
-      @tag_options[:data][:srcset] = srcset
-      @tag_options[:data][:sizes] ||= '100vw'
-      @tag_options[:data][:src] = url
-      image_tag(lazy_url, @tag_options)
+    if @attribute_options[:srcset].present?
+      @tag_options[@attribute_options[:srcset]] = srcset
+    else
+      @tag_options[:srcset] = srcset
+    end
+
+    if @attribute_options[:size].present?
+      @tag_options[@attribute_options[:size]] ||= '100vw'
     else
       @tag_options[:sizes] ||= '100vw'
-      @tag_options[:srcset] = srcset
-      image_tag(url, @tag_options)
     end
-  end
 
-  private
+    if @attribute_options[:src].present?
+      @tag_options[@attribute_options[:src]] = url
+    end
 
-  def lazy_url
-    if @lazy == true
-      "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs="
+    if @tag_options[:src].present?
+      image_tag(@tag_options[:src], @tag_options)
     else
-      @lazy
+      image_tag(url, @tag_options)
     end
   end
 end

--- a/lib/imgix/rails/image_tag.rb
+++ b/lib/imgix/rails/image_tag.rb
@@ -3,9 +3,28 @@ require "imgix/rails/tag"
 class Imgix::Rails::ImageTag < Imgix::Rails::Tag
 
   def render
-    @tag_options[:srcset] = srcset
-    @tag_options[:sizes] ||= '100vw'
+    url = ix_image_url(@source, @path, @url_params)
 
-    image_tag(ix_image_url(@source, @path, @url_params), @tag_options)
+    if @lazy
+      @tag_options[:data] ||= {}
+      @tag_options[:data][:srcset] = srcset
+      @tag_options[:data][:sizes] ||= '100vw'
+      @tag_options[:data][:src] = url
+      image_tag(lazy_url, @tag_options)
+    else
+      @tag_options[:sizes] ||= '100vw'
+      @tag_options[:srcset] = srcset
+      image_tag(url, @tag_options)
+    end
+  end
+
+  private
+
+  def lazy_url
+    if @lazy == true
+      "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs="
+    else
+      @lazy
+    end
   end
 end

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -5,13 +5,13 @@ class Imgix::Rails::Tag
   include Imgix::Rails::UrlHelper
   include ActionView::Helpers
 
-  def initialize(path, source: nil, tag_options: {}, url_params: {}, srcset_options: {}, lazy: nil)
+  def initialize(path, source: nil, tag_options: {}, url_params: {}, srcset_options: {}, attribute_options: {})
     @path = path
     @source = source
     @tag_options = tag_options
     @url_params = url_params
     @srcset_options = srcset_options
-    @lazy = lazy
+    @attribute_options = attribute_options
   end
 
 protected

--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -5,12 +5,13 @@ class Imgix::Rails::Tag
   include Imgix::Rails::UrlHelper
   include ActionView::Helpers
 
-  def initialize(path, source: nil, tag_options: {}, url_params: {}, srcset_options: {})
+  def initialize(path, source: nil, tag_options: {}, url_params: {}, srcset_options: {}, lazy: nil)
     @path = path
     @source = source
     @tag_options = tag_options
     @url_params = url_params
     @srcset_options = srcset_options
+    @lazy = lazy
   end
 
 protected

--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -8,8 +8,8 @@ module Imgix
     module ViewHelper
       include UrlHelper
 
-      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, srcset_options: {}, lazy: nil)
-        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, srcset_options: srcset_options, lazy: lazy).render
+      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, srcset_options: {}, attribute_options: {})
+        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, srcset_options: srcset_options, attribute_options: attribute_options).render
       end
 
       def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})

--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -8,8 +8,8 @@ module Imgix
     module ViewHelper
       include UrlHelper
 
-      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, srcset_options: {})
-        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, srcset_options: srcset_options).render
+      def ix_image_tag(source=nil, path, tag_options: {}, url_params: {}, srcset_options: {}, lazy: nil)
+        return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, srcset_options: srcset_options, lazy: lazy).render
       end
 
       def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -335,22 +335,17 @@ describe Imgix::Rails do
       end
       describe 'lazy' do
         it 'sets the original path to data-src' do
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: true)).children[0]
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", attribute_options: { src: "data-src", srcset: "data-srcset", sizes: "data-sizes"}, tag_options: {src: "lazy.jpg"})).children[0]
           expect(tag.attribute('data-src').value).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
         end
 
-        it 'sets src to gif if no image is provided' do
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: true)).children[0]
-          expect(tag.attribute('src').value).to include "data:image/gif"
-        end
-
         it 'sets src to image provided with lazy' do
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: "lazy-image.jpg")).children[0]
-          expect(tag.attribute('src').value).to eq "/images/lazy-image.jpg"
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", attribute_options: { src: "data-src", srcset: "data-srcset", sizes: "data-sizes"}, tag_options: {src: "lazy.jpg"})).children[0]
+          expect(tag.attribute('src').value).to eq "/images/lazy.jpg"
         end
 
         it 'keeps the sourcesets on data-sourcesets' do
-          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: true)).children[0]
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", attribute_options: { src: "data-src", srcset: "data-srcset", sizes: "data-sizes"}, tag_options: {src: "lazy.jpg"})).children[0]
           expect(tag.attribute('data-srcset').value.split(',').size).to eq(31)
         end
       end

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -333,6 +333,27 @@ describe Imgix::Rails do
           end
         end
       end
+      describe 'lazy' do
+        it 'sets the original path to data-src' do
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: true)).children[0]
+          expect(tag.attribute('data-src').value).to eq "https://assets.imgix.net/image.jpg?ixlib=rails-#{Imgix::Rails::VERSION}"
+        end
+
+        it 'sets src to gif if no image is provided' do
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: true)).children[0]
+          expect(tag.attribute('src').value).to include "data:image/gif"
+        end
+
+        it 'sets src to image provided with lazy' do
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: "lazy-image.jpg")).children[0]
+          expect(tag.attribute('src').value).to eq "/images/lazy-image.jpg"
+        end
+
+        it 'keeps the sourcesets on data-sourcesets' do
+          tag = Nokogiri::HTML.fragment(helper.ix_image_tag("image.jpg", lazy: true)).children[0]
+          expect(tag.attribute('data-srcset').value.split(',').size).to eq(31)
+        end
+      end
     end
 
     describe '#ix_picture_tag' do


### PR DESCRIPTION
# Description

Adds lazy support to `ix_image_tag` as described on #60. We need this in our project due to the amount of images being loaded on a single webpage, often from very bad network scenarios.

<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->

## Checklist: New Feature

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider [opening an issue](https://github.com/imgix/imgix-rails/issues/new?assignees=&labels=&template=feature_request.md&title=) to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!

## Steps to Test

Add `lazy: true` to an ix_image_tag:

```erb
<%= ix_image_tag 'image.jpg', lazy: true %>
```

Set an image to `lazy` to use it instead:

```erb
<%= ix_image_tag 'image.jpg', lazy: asset_pack_url('loading.gif') %>
```

Related issue: #60