### PR TITLE
feat: add img_tag_options to ix_picture_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 * `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
 * `path`: The path or URL of the image to display.
 * `tag_options`: Any options to apply to the parent `picture` element. This is useful for adding class names, etc.
-* `img_tag_options`: Any options to apply to the generated `img` element. This can be useful to add and `alt` attribute.
+* `img_tag_options`: Any options to apply to the generated `img` element. This can be useful to add an `alt` attribute.
 * `url_params`: Default imgix options. These will be used to generate a fallback `img` tag for older browsers, and used in each `source` unless overridden by `breakpoints`.
 * `breakpoints`: A hash describing the variants. Each key must be a media query (e.g. `(max-width: 880px)`), and each value must be a hash of parameter overrides for that media query. A `source` element will be generated for each breakpoint specified.
 * `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 * `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
 * `path`: The path or URL of the image to display.
 * `tag_options`: Any options to apply to the parent `picture` element. This is useful for adding class names, etc.
+* `img_tag_options`: Any options to apply to the generated `img` element. This can be useful to add and `alt` attribute.
 * `url_params`: Default imgix options. These will be used to generate a fallback `img` tag for older browsers, and used in each `source` unless overridden by `breakpoints`.
 * `breakpoints`: A hash describing the variants. Each key must be a media query (e.g. `(max-width: 880px)`), and each value must be a hash of parameter overrides for that media query. A `source` element will be generated for each breakpoint specified.
 * `srcset_options`: A variety of options that allow for fine tuning `srcset` generation. More information on each of these modifiers can be found in the [imgix-rb documentation](https://github.com/imgix/imgix-rb#srcset-generation). Any of the following can be passed as arguments:
@@ -227,6 +228,9 @@ The `ix_picture_tag` helper method makes it easy to generate `picture` elements 
 <%= ix_picture_tag('bertandernie.jpg',
   tag_options: {
     class: 'a-picture-tag'
+  },
+  img_tag_options: {
+    alt: 'A picture of Bert and Ernie arguing'
   },
   url_params: {
     w: 300,
@@ -267,6 +271,7 @@ To generate a `picture` element on a different source:
 ```erb
 <%= ix_picture_tag('assets2.imgix.net', 'bertandernie.jpg',
       tag_options: {},
+      img_tag_options: {},
       url_params: {},
       breakpoints: {
         '(max-width: 640px)' => {

--- a/lib/imgix/rails/picture_tag.rb
+++ b/lib/imgix/rails/picture_tag.rb
@@ -5,10 +5,11 @@ require "action_view"
 class Imgix::Rails::PictureTag < Imgix::Rails::Tag
   include ActionView::Context
 
-  def initialize(path, source: nil, tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})
+  def initialize(path, source: nil, tag_options: {}, img_tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})
     @path = path
     @source = source
     @tag_options = tag_options
+    @img_tag_options = img_tag_options
     @url_params = url_params
     @breakpoints = breakpoints
     @srcset_options = srcset_options
@@ -28,7 +29,7 @@ class Imgix::Rails::PictureTag < Imgix::Rails::Tag
         concat(content_tag(:source, nil, source_tag_opts))
       end
 
-      concat Imgix::Rails::ImageTag.new(@path, source: @source, url_params: @url_params, srcset_options: @srcset_options).render
+      concat Imgix::Rails::ImageTag.new(@path, source: @source, tag_options: @img_tag_options, url_params: @url_params, srcset_options: @srcset_options).render
     end
   end
 

--- a/lib/imgix/rails/view_helper.rb
+++ b/lib/imgix/rails/view_helper.rb
@@ -12,8 +12,8 @@ module Imgix
         return Imgix::Rails::ImageTag.new(path, source: source, tag_options: tag_options, url_params: url_params, srcset_options: srcset_options, attribute_options: attribute_options).render
       end
 
-      def ix_picture_tag(source=nil, path, tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})
-        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, url_params: url_params, breakpoints: breakpoints, srcset_options: srcset_options).render
+      def ix_picture_tag(source=nil, path, tag_options: {}, img_tag_options: {}, url_params: {}, breakpoints: {}, srcset_options: {})
+        return Imgix::Rails::PictureTag.new(path, source: source, tag_options: tag_options, img_tag_options: img_tag_options, url_params: url_params, breakpoints: breakpoints, srcset_options: srcset_options).render
       end
     end
   end

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -611,6 +611,35 @@ describe Imgix::Rails do
           end
         end
       end
+
+      context 'with img_tag_options' do
+        let(:tag) do
+          picture_tag = helper.ix_picture_tag(
+            'bertandernie.jpg',
+            tag_options: {
+              title: 'A picture of Bert and Ernie'
+            },
+            img_tag_options: {
+              alt: 'Bert and Ernie'
+            },
+            url_params: {
+              w: 300,
+              h: 300,
+              fit: 'crop',
+            }
+          )
+
+          Nokogiri::HTML.fragment(picture_tag).children[0]
+        end
+
+        it 'sets tag_attributes on picture' do
+          expect(tag.attr('title')).to eq 'A picture of Bert and Ernie'
+        end
+
+        it 'sets img_tag_attributes on img' do
+          expect(tag.css('img').first.attr('alt')).to eq 'Bert and Ernie'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Description

As suggested in #40 and #101, this PR adds an `img_tag_options` argument for `ix_picture_tag`. This can be used to futher customize the generated tags. It also updates the specs and README for documentation.

You can check the spec changes to see how this can be used.

Since this only adds an additional optional parameter, I don't expect any incompatibilities and therefore would **not** consider this a breaking change.

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [ ] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
