### PR TITLE
Expose disable path encoding on `imgix_image_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ The `ix_image_url` helper makes it easy to generate a URL to an image in your Ra
 
 * `source`: an optional String indicating the source to be used. If unspecified `:source` or `:default_source` will be used. If specified, the value must be defined in the config.
 * `path`: The path or URL of the image to display.
-* `options`: The imgix URL parameters to apply to this image URL.
+* `options`: The imgix URL parameters to apply to this image URL. Optionally, you can use `disable_path_encoding: false` for disabling URL-encoding which will be applied by default.
 
 ```erb
 <%= ix_image_url('/users/1/avatar.png', { w: 400, h: 300 }) %>
-<%= ix_image_url('assets2.imgix.net', '/users/1/avatar.png', { w: 400, h: 300 }) %>
+<%= ix_image_url('assets2.imgix.net', '/users/1/avatar.png', { w: 400, h: 300, disable_path_encoding: true }) %>
 ```
 
 Will generate the following URLs:

--- a/lib/imgix/rails/url_helper.rb
+++ b/lib/imgix/rails/url_helper.rb
@@ -6,6 +6,8 @@ module Imgix
       def ix_image_url(*args)
         validate_configuration!
 
+        disable_path_encoding = args.last.is_a?(Hash) && args.last.delete(:disable_path_encoding)
+
         case args.size
         when 1
           path = args[0]
@@ -31,7 +33,7 @@ module Imgix
           raise RuntimeError.new('path missing')
         end
 
-        imgix_client(source).path(path).to_url(params).html_safe
+        imgix_client(source).path(path).to_url(params, disable_path_encoding: disable_path_encoding).html_safe
       end
 
       protected

--- a/spec/imgix/rails/url_helper_spec.rb
+++ b/spec/imgix/rails/url_helper_spec.rb
@@ -11,10 +11,6 @@ describe Imgix::Rails::UrlHelper do
     end.new
   end
 
-  before do
-    Imgix::Rails.configure { |config| config.imgix = {} }
-  end
-
   describe 'configuration' do
     let(:app) { Class.new(::Rails::Application) }
     let(:source) { "assets.imgix.net" }


### PR DESCRIPTION
## Description

This is a very simple attempt at fixing https://github.com/imgix/imgix-rails/issues/124

<!-- Before this PR... -->

Already URL-encoded URLs generated by Paperclip were URL-encoded twice thus generating 404s and the `?` in URLs with asset fingerprint in the query was URL-encoded again generating 404s.

<!-- After this PR... -->

By passing `disable_path_encoding: true` it's possible to skip URL-encoding in `imgix_image_url`. Examples can be seen in added specs.

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [ ] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [ ] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
