### PR TITLE
fix: fix issue where breakpoint srcset_options weren't being used

### DIFF
--- a/lib/imgix/rails/tag.rb
+++ b/lib/imgix/rails/tag.rb
@@ -16,16 +16,16 @@ class Imgix::Rails::Tag
 
 protected
 
-  def srcset(source: @source, path: @path, url_params: @url_params, srcset_options: @srcset_options, tag_options: @tag_options)
+  def srcset(source: @source, path: @path, url_params: @url_params, srcset_options: @srcset_options)
     params = url_params.clone
 
     width_tolerance = ::Imgix::Rails.config.imgix[:srcset_width_tolerance]
-    min_width = @srcset_options[:min_width]
-    max_width = @srcset_options[:max_width]
-    widths = @srcset_options[:widths]
-    disable_variable_quality = @srcset_options[:disable_variable_quality]
-    options = { widths: widths, width_tolerance: width_tolerance, min_width: min_width, max_width: max_width, disable_variable_quality: disable_variable_quality}
+    min_width = srcset_options[:min_width]
+    max_width = srcset_options[:max_width]
+    widths = srcset_options[:widths]
+    disable_variable_quality = srcset_options[:disable_variable_quality]
+    options = {widths: widths, width_tolerance: width_tolerance, min_width: min_width, max_width: max_width, disable_variable_quality: disable_variable_quality}
 
-    ix_image_srcset(@source, @path, params, options)
+    ix_image_srcset(source, path, params, options)
   end
 end

--- a/spec/imgix/rails_spec.rb
+++ b/spec/imgix/rails_spec.rb
@@ -610,6 +610,39 @@ describe Imgix::Rails do
             expect(tag.children[1].attribute('src').value).not_to include('widths')
           end
         end
+
+        context 'breakpoint overrides' do
+          let(:tag) do
+            picture_tag = helper.ix_picture_tag(
+              'bertandernie.jpg',
+              srcset_options: {
+                widths: [100,200]
+              },
+              breakpoints: {
+                "800px": {
+                  srcset_options: {
+                    widths: [600,700]
+                  }
+                }
+              }
+            )
+            Nokogiri::HTML.fragment(picture_tag).children[0]
+          end
+
+          it 'uses base settings on img tag' do
+            expect(tag.children[1].attribute('srcset').value).to include('100w')
+            expect(tag.children[1].attribute('srcset').value).to include('200w')
+            expect(tag.children[1].attribute('srcset').value).not_to include('600w')
+            expect(tag.children[1].attribute('srcset').value).not_to include('700w')
+          end
+
+          it 'uses breakpoint override on source tag' do
+            expect(tag.children[0].attribute('srcset').value).not_to include('100w')
+            expect(tag.children[0].attribute('srcset').value).not_to include('200w')
+            expect(tag.children[0].attribute('srcset').value).to include('600w')
+            expect(tag.children[0].attribute('srcset').value).to include('700w')
+          end
+        end
       end
 
       context 'with img_tag_options' do


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description

When setting `srcset_options` on a breakpoint it was not being used by `Tag::srcset` instead defaulting
to the generic `srcset_options` (if provided). This change makes `srcset` used the options passed
to the method instead of the class-instance variables.
<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->

<!-- After this PR... -->

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
